### PR TITLE
feat: add optional lambda environment variables

### DIFF
--- a/post-scan-actions/aws-python-promote-or-quarantine/README.md
+++ b/post-scan-actions/aws-python-promote-or-quarantine/README.md
@@ -61,7 +61,8 @@ After a scan occurs, this example Lambda function places clean files in one buck
                 "Effect": "Allow",
                 "Action": [
                     "s3:PutObject",
-                    "s3:PutObjectTagging"
+                    "s3:PutObjectTagging",
+                    "s3:PutObjectAcl"
                 ],
                 "Resource": [
                     "arn:aws:s3:::<YOUR_QUARANTINE_BUCKET>/*",
@@ -308,3 +309,14 @@ To test that the Lambda function was deployed properly, you'll need to generate 
 
     **NOTE:** It can take about 30-60 seconds or more for the file to move.
     </details>
+
+## Optional Configuration
+Additional options are supported as described in the following section.
+
+- **Skip promotion/quarantine**
+    - If you wish to _only_ promote or _only_ quarantine, remove the environment variable corresponding to the action you want to ignore. For example to skip quarantine and promote only, remove the `QUARANTINEBUCKET` environment variable from the scanner Lambda configuration.
+- **Custom ACL (Access Control List)**
+    - An access control list (ACL) [defines which AWS accounts or groups are granted access and the type of access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl_overview.html).
+    - You can set a specific object ACL for promoted/quarantined objects. For example, if your source bucket has restricted permissions and you wish to grant wider access to promoted/quarantined objects, set the `ACL` environment variable in the scanner Lambda configuration, i.e., the value `bucket-owner-full-control` grants the promote/quarantine bucket access to the object as if it were there own.
+- **Change default promotion/quarantine behaviour**
+    - By default when an object is promoted or quarantined, it is _moved_ from the source bucket into either one of `PROMOTEBUCKET` or `QUARANTINEBUCKET`. That is, it's removed from the scanned bucket and copied to the destination bucket. If, for example, you wish to instead perform a _copy_ on promotion (i.e., pseudo object replication-like behaviour) then set the `PROMOTEMODE` environment variable in the scanner Lambda configuration to `copy` (default: `move`). Likewise, you _could_ do the same for quarantine by setting the `QUARANTINEMODE` variable to `copy` (though strongly **not** recommended).


### PR DESCRIPTION
Greetings,

Our usage of `aws-python-promote-or-quarantine` plugin has revealed some corner-cases that required slight modification to `handler.py` as well as the custom lambda execution policy (`YOUR_FSS_LAMBDA_POLICY`). Specifically, we have a source bucket with strict deny rules and have object replication configured on our promotion bucket. To get this plugin working we had to make two modifications:

- add the `s3:PutObjectAcl` action to the custom lambda exection policy
-  include the `ACL` parameter to the `copy_object` function (with a value of `bucket-owner-full-control` in our case)

I've not modified the current 'default' behavior of `handler.py` (though I did do some refactoring) but instead added environment variables which change the runtime behavior. If a user were to follow the documentation as it is in this PR (pretty much the same as in `master`), the behavior _should_ be the same as it is today. Appended to the `README.md` is a breakdown of optional configuration that enables (or disables) the features described in this PR. Lastly, for our use case we wanted to keep quarantined objects in the source bucket and **copy** promoted ones.

So to support the aforementioned features -- the following environment variables are proposed :

- `ACL`
  - Can be one of:
     ```
      'private'|'public-read'|'public-read-write'|'authenticated-read'|'aws-exec-read'|'bucket-owner-read'|'bucket-owner-full-control'
      ```
    - Is only append to the request body if `not None`
- `PROMOTEMODE`
    - Can be one of:
       ```'move'|'copy'```
    - The default is `move` (the behavior as it is today)
    - The `copy` option does not delete the original
    - Rationale behind making it a string constant: easy to add support for different behaviors in the future
- `QUARANTINEMODE`
    - The same as `PROMOTEMODE` except pertaining to the quarantine bucket and malicious objects

Finally, I've refactored the code such that if either `PROMOTEBUCKET` or `QUARANTINEBUCKET` is _not_ set, the corresponding action is skipped (but logged).

The one thing I'm hesitant about is including by default the `s3:PutObjectAcl` in the lambda exec role because it's only required if one were to set the `ACL` environment variable. We could make it an optional action to include in the policy but I didn't want to convolute the documentation and will leave that defer the decision to you.

I've tested execution in various configurations but obviously I'm only human and cannot run an exhaustive test suite on my own but from what I was able to test, all seemed to work. Please let me know if anything is unclear or further edits are required.

Thanks,

Misha