### PR TITLE
feat: fss-to-conformity-custom-check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ zip/
 
 # SAM
 packaged.yaml
+*.toml

--- a/post-scan-actions/aws-python-conformity-custom-check/README.md
+++ b/post-scan-actions/aws-python-conformity-custom-check/README.md
@@ -1,0 +1,57 @@
+# Cloud One File Storage Security Post Scan Action - Conformity Custom Check
+
+After a scan occurs and a malicious file is detected, this example Lambda function creates a custom check within Cloud One Conformity.
+
+## Prerequisites
+
+1. **Configure Conformity API Key**
+    - Log into Conformity and select your username and select `User settings`.
+    - Select `API Keys`.
+    - Select `+ New API Key`, then select `Generate Key`.
+    - Copy the generated API Key for use later when installing the function.
+2. **Find the 'ScanResultTopicARN' SNS topic ARN**
+    - In the AWS console, go to **Services > CloudFormation** > your all-in-one stack > **Outputs**  or **Services > CloudFormation** > your storage stack > **Outputs**.
+    - Scroll down to locate the  **ScanResultTopicARN** Key.
+    - Copy the **ScanResultTopic** ARN to a temporary location. Example: `arn:aws:sns:us-east-1:123445678901:FileStorageSecurity-All-In-One-Stack-StorageStack-1IDPU1PZ2W5RN-ScanResultTopic-N8DD2JH1GRKF`
+
+## Installation
+
+### From AWS Lambda Console
+
+1. Visit [the app's page on the AWS Lambda Console](https://console.aws.amazon.com/lambda/home?#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:415485722356:applications/cloudone-filestorage-plugin-action-conformity-custom-check).
+2. Fill in the parameters.
+3. Select the `I acknowledge that this app creates custom IAM roles.` checkbox.
+4. Select `Deploy`.
+
+### Embed as a Nested App in Your Serverless Application
+
+1. Visit [the app's page on the AWS Lambda Console](https://console.aws.amazon.com/lambda/home?#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:415485722356:applications/cloudone-filestorage-plugin-action-conformity-custom-check).
+2. Select the `Copy as SAM Resource` button and paste the copied YAML into your SAM template, filling in any required parameters.
+
+## Test the Application
+
+To test that the application was deployed properly, you'll need to generate a malware detection using the [eicar test file](https://secure.eicar.org/eicar.com "A file used for testing anti-malware scanners."), and then check the Quarantine bucket to make sure the `eicar` file was sent there successfully.
+
+1. **Download the Eicar test file**
+   - Temporarily disable your virus scanner or create an exception, otherwise it will catch the `eicar` file and delete it.
+   - Browser: Go to the [eicar file](https://secure.eicar.org/eicar.com) page and download `eicar_com.zip` or any of the other versions of this file.
+   - CLI: `curl -O https://secure.eicar.org/eicar_com.zip`
+2. **Upload the eicar file to the ScanningBucket**
+
+    - Using the AWS console
+
+        1. Go to **CloudFormation > Stacks** > your all-in-one stack > your nested storage stack.
+        2. In the main pane, select the **Outputs** tab and then copy the **ScanningBucket** string. Search the string in Amazon S3 console to find your ScanningBucket.
+        3. Select **Upload** and upload `eicar_com.zip`. File Storage Security scans the file and detects malware.
+        4. Within Conformity select **Browse All Checks** you should now see the malicious file finding under the Check ID specified when creating the function. Example: `CUSTOM-001`
+
+        > 📌 It can take 15-30 seconds for the event to appear within Conformity.
+
+    - Using the AWS CLI
+
+        - Enter the folowing AWS CLI command to upload the Eicar test file to the scanning bucket:
+            `aws s3 cp eicar_com.zip s3://<YOUR_SCANNING_BUCKET>`
+        - where:
+            - `<YOUR_SCANNING_BUCKET>` is replaced with the ScanningBucket name.
+
+        > 📌 It can take 15-30 seconds for the event to appear within Conformity.

--- a/post-scan-actions/aws-python-conformity-custom-check/handler.py
+++ b/post-scan-actions/aws-python-conformity-custom-check/handler.py
@@ -1,0 +1,135 @@
+import boto3
+import json
+import os
+import urllib3
+
+# import datetime
+
+http = urllib3.PoolManager()
+
+region = os.environ.get("CC_REGION", "us-west-2")
+ccsecretsarn = os.environ["CC_API_SECRETS_ARN"]
+customcheckid = os.environ.get("CC_CUSTOMCHECKID", "CUSTOM-001").upper()
+customchecksev = os.environ.get("CC_CHECKSEV", "VERY_HIGH").upper()
+
+secrets = boto3.client("secretsmanager").get_secret_value(SecretId=ccsecretsarn)
+secrets_data = json.loads(secrets["SecretString"])
+apikey = secrets_data["ccapikey"]
+
+headers = {
+    "Content-Type": "application/vnd.api+json",
+    "Authorization": "ApiKey " + apikey,
+}
+
+
+def get_cc_accountid(awsaccountid):
+    accountsapi = f"https://{region}-api.cloudconformity.com/v1/accounts"
+    r = http.request("GET", accountsapi, headers=headers)
+    accounts = json.loads(r.data.decode("utf-8"))["data"]
+    for account in accounts:
+        if account["attributes"]["awsaccount-id"] == awsaccountid:
+            return account["id"]
+
+
+def lambda_handler(event, context):
+
+    for record in event["Records"]:
+
+        # Message details from SNS event
+        message = json.loads(record["Sns"]["Message"])
+        print(record["Sns"]["Message"])
+        findings = message["scanning_result"].get("Findings")
+
+        if findings:
+            # Get AWS Account Info
+            arn = json.dumps(record["EventSubscriptionArn"])
+            aws_region = arn.split(":")[3].strip()
+            account_id = arn.split(":")[4].strip()
+            # Get Conformity Account ID for AWS Account
+            ccaccountid = get_cc_accountid(account_id)
+
+            # Get the bucket & object details
+            bucketname = message["file_url"].split(".s3.amazonaws.com/")[0][8:]
+            fileprefix = message["file_url"].split(".s3.amazonaws.com/")[1]
+            filename = message["file_url"].split("/")[-1]
+            s3uri = f"s3://{bucketname}/{fileprefix}"
+            s3arn = f"arn:aws:s3:::{bucketname}/{fileprefix}"
+            s3consoleurl = f"https://s3.console.aws.amazon.com/s3/buckets/{bucketname}?region={aws_region}&prefix={fileprefix}"
+
+            # Generate TTL to expire message (not currently supported by conformity custom checks api - coming soon?)
+            # timenow = datetime.datetime.now()
+            # ttl = timenow + datetime.timedelta(days=1)
+            # ttlepoch = round(datetime.datetime.timestamp(ttl))
+
+            malwares = []
+            types = []
+            for finding in message["scanning_result"]["Findings"]:
+                malwares.append(finding.get("malware"))
+                types.append(finding.get("type"))
+
+                checksdata = {
+                    "data": [
+                        {
+                            "type": "checks",
+                            "attributes": {
+                                "rule-title": "C1 File Storage Security - Malware Detected",
+                                "message": f"Object {filename} in bucket {bucketname} contains malware",
+                                "not-scored": False,
+                                "region": aws_region,
+                                "resource": s3uri.replace("/", ":"),
+                                "risk-level": customchecksev,
+                                "status": "FAILURE",
+                                "service": "S3",
+                                "categories": ["security"],
+                                "link": s3consoleurl,
+                                # "ttl": ttlepoch,
+                                "extradata": [
+                                    {
+                                        "label": "Malware Name",
+                                        "name": "Malware Name",
+                                        "type": "Meta",
+                                        "value": ", ".join(malwares),
+                                    },
+                                    {
+                                        "label": "Malware Type",
+                                        "name": "Malware Type",
+                                        "type": "Meta",
+                                        "value": ", ".join(types),
+                                    },
+                                    {
+                                        "label": "S3 URI",
+                                        "name": "S3 URI",
+                                        "type": "Meta",
+                                        "value": s3uri,
+                                    },
+                                    {
+                                        "label": "S3 ARN",
+                                        "name": "S3 ARN",
+                                        "type": "Meta",
+                                        "value": s3arn,
+                                    },
+                                    {
+                                        "label": "S3 Console URL",
+                                        "name": "S3 Console URL",
+                                        "type": "Meta",
+                                        "value": s3consoleurl,
+                                    },
+                                ],
+                            },
+                            "relationships": {
+                                "account": {
+                                    "data": {"id": ccaccountid, "type": "accounts"}
+                                },
+                                "rule": {
+                                    "data": {"id": customcheckid, "type": "rules"}
+                                },
+                            },
+                        }
+                    ]
+                }
+
+                bodyencoded = json.dumps(checksdata).encode("utf-8")
+                checksapi = f"https://{region}-api.cloudconformity.com/v1/checks"
+
+                r = http.request("POST", checksapi, body=bodyencoded, headers=headers)
+                print(r.data.decode("utf-8"))

--- a/post-scan-actions/aws-python-conformity-custom-check/template.yml
+++ b/post-scan-actions/aws-python-conformity-custom-check/template.yml
@@ -1,0 +1,83 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: cloudone-filestorage-plugin-action-conformity-custom-check
+    Description: >-
+      After a scan occurs, this example application places pushes an alert to Cloud One Conformity using Custom Checks.
+    Author: Trend Micro Cloud One File Storage Security
+    SpdxLicenseId: Apache-2.0
+    LicenseUrl: ../../LICENSE
+    ReadmeUrl: README.md
+    Labels: [trendmicro, cloudone, filestorage, s3, bucket, plugin, conformity, customcheck]
+    HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
+    SemanticVersion: 1.0.0
+    SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-conformity-custom-check
+
+Parameters:
+  SNSTopicArn:
+    Type: String
+    Description: ARN of the File Storage SNS Topic to subscribe this function.
+  ConformityRegion:
+    Type: String
+    Description: Region where you conformity account is hosted. (us-west-2 for Cloud One customers)
+    Default: us-west-2
+    AllowedValues:
+      - us-west-2
+      - ap-southeast-2
+      - eu-west-1
+  ConformityApiKey:
+    Type: String
+    NoEcho: true
+    Description: Enter your Conformity API Key. (https://www.cloudconformity.com/help/public-api/api-keys.html)
+  ConformityCustomCheckId:
+    Type: String
+    Description: Enter the custom check ID number to track FSS findings as in Conformity. (Allowed values CUSTOM-{001-999})
+    Default: CUSTOM-001
+    AllowedPattern: CUSTOM-(?=.*[1-9])\d{3}?$
+  ConformityCheckSeverity:
+    Type: String
+    Description: Please enter the severity level to track FSS findings as in Conformity.
+    Default: VERY_HIGH
+    AllowedValues:
+      - LOW
+      - MEDIUM
+      - HIGH
+      - VERY_HIGH
+      - EXTREME
+
+Resources:
+  FSStoConformityChecksSecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Conformity API Key Secret
+      SecretString: !Sub '{"ccapikey":"${ConformityApiKey}"}'
+
+  FSStoConformityChecksFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: handler.lambda_handler
+      Runtime: python3.8
+      MemorySize: 128
+      Timeout: 30
+      Tracing: Active
+      Environment:
+        Variables:
+          CC_REGION: !Ref ConformityRegion
+          CC_API_SECRETS_ARN: !Ref FSStoConformityChecksSecret
+          CC_CUSTOMCHECKID: !Ref ConformityCustomCheckId
+          CC_CHECKSEV: !Ref ConformityCheckSeverity
+      Policies:
+        - Statement:
+            - Sid: GetSecretValue
+              Effect: Allow
+              Action:
+                - secretsmanager:GetSecretValue
+              Resource: !Ref FSStoConformityChecksSecret
+      Events:
+        ScanResult:
+          Type: SNS
+          Properties:
+            Topic: !Ref SNSTopicArn


### PR DESCRIPTION
# Feature: New Post Scan Action Plugin - Cloud One Conformity Custom Check

## Change Summary
This change adds a new post-scan action to publish malicious file details to Trend Micro's Cloud One Conformity product as a Custom Check.
## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
    - [x] Updated accordingly
    - [ ] Not required

## Other Notes
Currently, the conformity custom checks endpoint does not support forward slashes in resource names so the name format for the resource is the S3 URI with forward slashes replaced by colons.
Also support for TTL to auto expire messages has been built into code but commented out in anticipation for a future update to Conformity to allow users to specify TTLs with Custom Checks.
<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
Example custom check when viewed within Conformity:

![image](https://user-images.githubusercontent.com/25472582/111619165-55dd1e00-8839-11eb-8bc2-7e61b016646c.png)
