### PR TITLE
fix: conformity-postscan-plugin-account-lookup

### DIFF
--- a/post-scan-actions/aws-python-conformity-custom-check/handler.py
+++ b/post-scan-actions/aws-python-conformity-custom-check/handler.py
@@ -27,8 +27,11 @@ def get_cc_accountid(awsaccountid):
     r = http.request("GET", accountsapi, headers=headers)
     accounts = json.loads(r.data.decode("utf-8"))["data"]
     for account in accounts:
-        if account["attributes"]["awsaccount-id"] == awsaccountid:
-            return account["id"]
+        try:
+            if account["attributes"]["awsaccount-id"] == awsaccountid:
+                return account["id"]
+        except:
+            pass
 
 
 def lambda_handler(event, context):

--- a/post-scan-actions/aws-python-conformity-custom-check/template.yml
+++ b/post-scan-actions/aws-python-conformity-custom-check/template.yml
@@ -12,7 +12,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: [trendmicro, cloudone, filestorage, s3, bucket, plugin, conformity, customcheck]
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 1.0.0
+    SemanticVersion: 1.0.1
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-conformity-custom-check
 
 Parameters:


### PR DESCRIPTION
# Fix: Fixes account lookup error in conformity plugin

## Fix to prevent script erroring out when azure subscriptions are present within a C1 Conformity tenant.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
    - [ ] Updated accordingly
    - [x] Not required

## Other Notes

Error without this fix and azure subscriptions present:
[ERROR] KeyError: 'awsaccount-id'
Traceback (most recent call last):
  File "/var/task/handler.py", line 49, in lambda_handler
    ccaccountid = get_cc_accountid(account_id)

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
