### PR TITLE
fix: fss conformity custom check bucketname / path generation

### DIFF
--- a/post-scan-actions/aws-python-conformity-custom-check/template.yml
+++ b/post-scan-actions/aws-python-conformity-custom-check/template.yml
@@ -12,7 +12,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: [trendmicro, cloudone, filestorage, s3, bucket, plugin, conformity, customcheck]
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 1.0.1
+    SemanticVersion: 1.0.2
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-conformity-custom-check
 
 Parameters:


### PR DESCRIPTION
# Title 
Fix bucket & fileprefix object when bucket is in region other than us-east-1

## Change Summary
Fixes the split to support regions other than us-east-1
## PR Checklist

- [X] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
    - [ ] Updated accordingly
    - [X] Not required

## Other Notes

Error without this fix:
`[ERROR] IndexError: list index out of range
Traceback (most recent call last):
  File "/var/task/handler.py", line 56, in lambda_handler
    fileprefix = message["file_url"].split(".s3.amazonaws.com/")[1]
[ERROR] IndexError: list index out of range Traceback (most recent call last):   File "/var/task/handler.py", line 56, in lambda_handler     fileprefix = message["file_url"].split(".s3.amazonaws.com/")[1]`

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
