### PR TITLE
docs: Fix command to publish Azure function

### DIFF
--- a/post-scan-actions/azure-python-promote-or-quarantine/README.md
+++ b/post-scan-actions/azure-python-promote-or-quarantine/README.md
@@ -57,14 +57,14 @@ After a scan occurs, this example Azure function places clean files in one stora
     quarantineMode=copy
     ```
 
-### 2. Public Azure function
+### 2. Publish Azure function
 
 1. Download [cloudone-filestorage-plugins repository](https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master)
 1. Navigate to `post-scan-actions/azure-python-promote-or-quarantine/promoteOrQuarantineFunction`
-1. Deploy the function to the function app:
+1. Publish the function to the function app:
 
     ```bash
-    func azure functionapp publish $FUNCTION_NAME
+    func azure functionapp publish $FUNCTION_NAME --python
     ```
 
 ## Test the function


### PR DESCRIPTION
# docs: Fix command to publish Azure function

## Change Summary

Specify worker runtime when publishing Azure function.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
