### PR TITLE
docs: minor improvements for README.md

### DIFF
--- a/post-scan-actions/aws-python-email-notification/README.md
+++ b/post-scan-actions/aws-python-email-notification/README.md
@@ -8,7 +8,7 @@ After a scan occurs, this example Lambda function sends out a notification Email
     - Install the AWS command line interface (CLI). See [Installing the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) for details.
     - Install GNU Make if you don't want to use the AWS CLI. See [GNU Make](https://www.gnu.org/software/make/) for download information.
 2. **Configure Amazon Simple Email Servie**
-    - Verify the Email addresses you are going to use for sending the Email notifications as well as the recipient's Email address.
+    - Verify the Email addresses you are going to use for sending the Email notifications as well as the recipient's Email address. See [Verifying email addresses in Amazon SES](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-email-addresses.html).
 3. **Create a custom policy**
 
     <details>
@@ -24,7 +24,6 @@ After a scan occurs, this example Lambda function sends out a notification Email
         - In the **Name** field, enter a name. Example: `FSS_SES_Send_Email_Policy`.
         - Click **Create policy**.
     8. Click the link to your policy to open its summary.
-    9. Take note of the **Policy ARN** near the top of the page.
     </details>
 
     <details>
@@ -218,14 +217,22 @@ After a scan occurs, this example Lambda function sends out a notification Email
 
 <details>
 <summary>Using the AWS console</summary>
+    
+1. **Find the 'ScanResultTopic' SNS topic ARN**
 
-1. Go to **Services > Lambda**.
-2. Search for the Lambda function you created previously. Example: `FSS_Scan_Send_Email`
-3. Click the link to your Lambda function to view its details.
-4. Click **Add trigger** on the left.
-5. From the **Trigger configuration** list, select **SNS**.
-6. In the **SNS topic** field, enter the SNS topic ARN you found earlier.
-7. Click **Add**. Your Lambda is now subscribed to the SNS topic.
+    - In the AWS console, go to **Services > CloudFormation** > your all-in-one stack > **Resources** > your storage stack > **Resources**.
+    - Scroll down to locate the  **ScanResultTopic** Logical ID. 
+    - Take note of the **ScanResultTopic** ARN. Example: `arn:aws:sns:us-east-1:123445678901:FileStorageSecurity-All-In-One-Stack-StorageStack-1IDPU1PZ2W5RN-ScanResultTopic-N8DD2JH1GRKF`
+
+2. **Set the Lambda function trigger**
+
+    - Go to **Services > Lambda**.
+    - Search for the Lambda function you created previously. Example: `FSS_Scan_Send_Email`
+    - Click the link to your Lambda function to view its details.
+    - Click **Add trigger** on the left.
+    - From the **Trigger configuration** list, select **SNS**.
+    - In the **SNS topic** field, enter the SNS topic ARN you found earlier.
+    - Click **Add**. Your Lambda is now subscribed to the SNS topic.
 
 </details>
 
@@ -236,6 +243,7 @@ After a scan occurs, this example Lambda function sends out a notification Email
     - In the AWS console, go to **Services > CloudFormation** > your all-in-one stack > **Resources** > your storage stack > **Resources**.
     - Scroll down to locate the  **ScanResultTopic** Logical ID. 
     - Copy the **ScanResultTopic** ARN to a temporary location. Example: `arn:aws:sns:us-east-1:123445678901:FileStorageSecurity-All-In-One-Stack-StorageStack-1IDPU1PZ2W5RN-ScanResultTopic-N8DD2JH1GRKF`
+
 2. **Find the Lambda function ARN**
     
     📌 The Lamdba function ARN is required only if you plan to use the AWS CLI (as opposed to the console) to subscribe the Lambda to the SNS topic.


### PR DESCRIPTION
# docs: minor improvements for README.md

## Change Summary
Change the following on post-scan-actions/aws-python-email-notification/README.md
- add link to the SES document
- delete steps to take note of Policy ARN because there's no step to use it.
- add steps to copy SNS Topic URL to [Subscribe the Lambda to the SNS topic]>[Using the AWS console] because there's no step to copy ScanResultTopic ARN.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes
I enhanced this Post Scan Action README where I was a bit confused when utilizing it. 
I'm not very familiar with GitHub, so please point out any mistakes in the commit messages or operations.
Thanks!
<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
