### PR TITLE
docs: Fix instructions on how to create conformity API Key

### DIFF
--- a/post-scan-actions/aws-python-conformity-custom-check/README.md
+++ b/post-scan-actions/aws-python-conformity-custom-check/README.md
@@ -4,10 +4,13 @@ After a scan occurs and a malicious file is detected, this example Lambda functi
 
 ## Prerequisites
 
-1. **Configure Conformity API Key**
-    - Log into Conformity and select your username and select `User settings`.
-    - Select `API Keys`.
-    - Select `+ New API Key`, then select `Generate Key`.
+1. **Configure Cloud One API Key for Conformity**
+    - In the upper-right corner of the Trend Micro Cloud One console, select the account where you want to add an API key.
+    - Once you have selected the account name, click the down-arrow to expand the drop-down box and click **Account Settings**.
+    - On the left, click **API Keys**
+    - Click **New** to create a new API key.
+    - In the New API Key dialog box, fill out the **API Key Alias** field, then select an appropriate option from the **Role** drop-down box, the **Language** drop-down box, and the **Timezone** drop-down box.
+    - Click the **Next** button to generate the new API key.
     - Copy the generated API Key for use later when installing the function.
 2. **Find the 'ScanResultTopicARN' SNS topic ARN**
     - In the AWS console, go to **Services > CloudFormation** > your all-in-one stack > **Outputs**  or **Services > CloudFormation** > your storage stack > **Outputs**.


### PR DESCRIPTION
# docs: Fix instructions on how to create conformity API Key

## Change Summary

- Modify the instructions on how to create an API Key before installing conformity-custom-check plugin
- fix issue #81 

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
