### PR TITLE
feat: Add GCP Promote and Quarantine Plugin

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -10,9 +10,11 @@
     "boto",
     "botocore",
     "eicar",
+    "gcloud",
     "pqfunction",
     "Spdx",
     "strftime",
+    "tfvars",
     "urlunsplit"
   ],
   "ignoreWords": [

--- a/post-scan-actions/gcp-python-promote-or-quarantine/Makefile
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/Makefile
@@ -1,0 +1,5 @@
+SRC_DIR = $(CURDIR)/src
+PLUGIN_ZIP_NAME = gcp-promote-and-quarantine-plugin.zip
+
+build:
+	cd $(SRC_DIR) && zip $(CURDIR)/$(PLUGIN_ZIP_NAME) *.py requirements.txt

--- a/post-scan-actions/gcp-python-promote-or-quarantine/README.md
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/README.md
@@ -1,0 +1,43 @@
+# Cloud One File Storage Security Post Scan Action for GCP - Promote or Quarantine
+
+**Warning: GCP solution is not yet in GA phase.**
+
+## Prerequisites
+
+1. **Install supporting tools**
+   - [Google Cloud SDK](https://cloud.google.com/sdk/docs/install-sdk)
+   - [Terraform](https://www.terraform.io/downloads)
+
+## Installation
+
+### With GCP Cloud Shell
+
+1. Visit [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftrendmicro%2Fcloudone-filestorage-plugins.git&cloudshell_workspace=post-scan-actions%2Fgcp-python-promote-or-quarantine&cloudshell_tutorial=docs/deploy-tutorial.md)
+
+### LocalMachine
+
+1. Login to the Google cloud SDK
+
+   ```sh
+   gcloud init
+   ```
+
+1. Create a function zip for the deployment using make.
+
+   ```sh
+   make
+   ```
+
+1. Initialize terraform.
+
+   ```sh
+   terraform init
+   ```
+
+1. Deploy the function and fill the variables following the CLI. (Or using the `main.auto.tfvars` file)
+
+   ```sh
+   terraform apply
+   ```
+
+   Instead of filling in the variables individually, you can create and use a `main.auto.tfvars` file. Enter the variables in to the `main.auto.tfvars.example` file, and then save the file as `main.auto.tfvars`. Once you have created and saved the file, you can reuse the file rather than fill in the variables every time.

--- a/post-scan-actions/gcp-python-promote-or-quarantine/docs/deploy-tutorial.md
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/docs/deploy-tutorial.md
@@ -1,0 +1,39 @@
+# Cloud One File Storage Security Post Scan Action for GCP - Promote or Quarantine
+
+## Overview
+
+<walkthrough-tutorial-duration duration="10"></walkthrough-tutorial-duration>
+
+This tutorial will guide you to deploy a promote and quarantine function.
+
+## Project Setup
+
+Copy the execute the script below to select the project where the storage stack is deployed.
+
+<walkthrough-project-setup></walkthrough-project-setup>
+
+```sh
+gcloud config set project <walkthrough-project-id/>
+```
+
+## Deploy promote and quarantine function
+
+1. Create a function zip for the deployment using make.
+
+    ```sh
+    make
+    ```
+
+1. Initialize terraform.
+
+    ```sh
+    terraform init
+    ```
+
+1. Deploy the function and fill the variables following the CLI. (Or using the `main.auto.tfvars` file)
+
+    ```sh
+    terraform apply
+    ```
+
+    Instead of filling in the variables individually, you can create and use a `main.auto.tfvars` file. Enter the variables in to the `main.auto.tfvars.example` file, and then save the file as `main.auto.tfvars`. Once you have created and saved the file, you can reuse the file rather than fill in the variables every time.

--- a/post-scan-actions/gcp-python-promote-or-quarantine/main.auto.tfvars.example
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/main.auto.tfvars.example
@@ -1,0 +1,14 @@
+project_settings = {
+    project_id = "<GCP_PROJECT_ID>" // e.g. test-project-998877
+    region = "<GCP_REGION>" // e.g. us-central1
+    plugin_prefix = "<CLOUD_FUNCTION_PREFIX>" // e.g. test-for-fss
+}
+
+deployment_name = "<DEPLOYMENT_NAME>" // e.g. test-deployment
+
+scan_result_topic = "<TOPIC_NAME>" // e.g. my-deployment-scan-result-topic
+scanning_bucket = "<SCANNING_BUCKET_NAME>" // e.g. scanning-gcs-bucket
+quarantine_mode = "move" // move or copy leave it empty
+quarantine_bucket = "<QUARANTINE_BUCKET_NAME>" // e.g. quarantine-gcs-bucket Leave it empty if you don't want to quarantine files.
+promote_mode = "move" // move or copy
+promote_bucket = "<PROMOTE_BUCKET_NAME>" // e.g. promote-gcs-bucket Leave it empty if you don't want to promote files.

--- a/post-scan-actions/gcp-python-promote-or-quarantine/main.tf
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/main.tf
@@ -1,0 +1,113 @@
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 4.0.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_settings.project_id
+  region = var.project_settings.region
+}
+
+resource "random_id" "deploy_suffix" {
+  keepers = {
+    # Generate a new suffix each time we switch to a new deployment
+    deployment_name = "${var.deployment_name}"
+  }
+
+  byte_length = 5
+}
+
+resource "google_service_account" "service_account" {
+  account_id = "qua-pro-plugin-sa-${lower(random_id.deploy_suffix.hex)}"
+  display_name = "Quarantine/Promote plugin Service Account"
+  project = var.project_settings.project_id
+}
+
+resource "google_project_iam_custom_role" "promote_and_quarantine_bucket_role" {
+  role_id = "plugin_storage_bucket_write_${lower(random_id.deploy_suffix.hex)}"
+  title = "Promote/Quarantine Bucket Write"
+  permissions = [
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.update"
+  ]
+}
+
+resource "google_project_iam_custom_role" "scanning_bucket_access_role" {
+  role_id = "plugin_storage_bucket_access_${lower(random_id.deploy_suffix.hex)}"
+  title = "Scanning Bucket Access"
+  permissions = var.promote_mode == "move" || var.quarantine_mode == "move" ? [
+    "storage.objects.delete",
+    "storage.objects.get",
+  ] : [
+    "storage.objects.get",
+  ]
+}
+
+resource "google_storage_bucket_iam_binding" "binding_promote_bucket" {
+  count = var.promote_bucket != "" ? 1 : 0
+  bucket = var.promote_bucket
+  role = google_project_iam_custom_role.promote_and_quarantine_bucket_role.role_id
+  members = [
+    "serviceAccount:${google_service_account.service_account.email}",
+  ]
+}
+
+resource "google_storage_bucket_iam_binding" "binding_quarantine_bucket" {
+  count = var.quarantine_bucket != "" ? 1 : 0
+  bucket = var.quarantine_bucket
+  role = google_project_iam_custom_role.promote_and_quarantine_bucket_role.role_id
+  members = [
+    "serviceAccount:${google_service_account.service_account.email}",
+  ]
+}
+
+resource "google_storage_bucket_iam_binding" "binding_scanning_bucket" {
+  bucket = var.scanning_bucket
+  role = google_project_iam_custom_role.scanning_bucket_access_role.role_id
+  members = [
+    "serviceAccount:${google_service_account.service_account.email}",
+  ]
+}
+
+resource "google_storage_bucket" "artifacts_bucket" {
+  name = "artifacts-promote-and-quarantine-plugin-${lower(random_id.deploy_suffix.hex)}"
+  location = var.project_settings.region
+  project = var.project_settings.project_id
+  uniform_bucket_level_access = true
+  force_destroy = true
+}
+
+resource "google_storage_bucket_object" "archive" {
+  name   = "gcp-promote-and-quarantine-plugin.zip"
+  bucket = google_storage_bucket.artifacts_bucket.name
+  source = "gcp-promote-and-quarantine-plugin.zip"
+}
+
+resource "google_cloudfunctions_function" "promote_and_quarantining_plugin" {
+  name = "${var.project_settings.plugin_prefix}-promote-and-quarantine-${random_id.deploy_suffix.hex}"
+  description = "Promote and Quarantine plugin"
+  source_archive_bucket = google_storage_bucket.artifacts_bucket.name
+  source_archive_object = "gcp-promote-and-quarantine-plugin.zip"
+  runtime = "python38"
+  entry_point = "main"
+  project = var.project_settings.project_id
+
+  event_trigger {
+    event_type = "providers/cloud.pubsub/eventTypes/topic.publish"
+    resource = "projects/${var.project_settings.project_id}/topics/${var.scan_result_topic}"
+  }
+
+  environment_variables = {
+    QUARANTINE_STORAGE_BUCKET = var.quarantine_bucket
+    QUARANTINE_MODE = var.quarantine_mode
+    PROMOTE_STORAGE_BUCKET = var.promote_bucket
+    PROMOTE_MODE = var.promote_mode
+  }
+
+  service_account_email = google_service_account.service_account.email
+}

--- a/post-scan-actions/gcp-python-promote-or-quarantine/src/main.py
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/src/main.py
@@ -1,0 +1,129 @@
+import base64
+import json
+import logging
+import os
+import time
+import urllib.parse
+
+from google.cloud import storage
+
+MODES = {
+    'move',
+    'copy',
+}
+DEFAULT_MODE = 'move'
+
+FSS_TAG_PREFIX = 'fss-'
+
+CODE_EMPTY = 0
+CODE_SKIP_MULTIPLE = 100
+CODE_MISC = 199
+
+CODE_MESSAGES = {
+    CODE_EMPTY: '',
+    CODE_SKIP_MULTIPLE: 'incomplete scan due to multiple reasons',
+    101: 'incomplete archive file extraction due to file too large',
+    102: 'incomplete archive file extraction due to too many files in archive',
+    103: 'incomplete archive file extraction due to too many archive layers',
+    104: 'incomplete archive file extraction due to compression ratio exceeds limit',
+    105: 'incomplete archive file extraction due to unsupported compression method',
+    106: 'incomplete archive file extraction due to corrupted compression file',
+    107: 'incomplete archive file extraction due to archive file encryption',
+    108: 'incomplete scan due to Microsoft Office file encryption',
+    CODE_MISC: 'incomplete scan due to miscellaneous reason. Provide the fss-scan-detail-code tag value to Trend Micro support',
+}
+
+def parse_object_url(input_url):
+    url = urllib.parse.urlparse(input_url)
+    paths = url.path.split('/', 2)
+    return paths[1], urllib.parse.unquote(paths[2])
+
+def main(event, context):
+    print(f'Context: {context}')
+
+    base64_data = event.get('data', '')
+    base64_bytes = base64_data.encode('ascii')
+    message_bytes = base64.b64decode(base64_bytes)
+    message = json.loads(message_bytes.decode('ascii'))
+    print(f'Message: {message}')
+
+    bucket_name, object_name = parse_object_url(message['file_url'])
+
+    quarantine_storage_bucket = os.environ.get('QUARANTINE_STORAGE_BUCKET')
+    promote_storage_bucket = os.environ.get('PROMOTE_STORAGE_BUCKET')
+
+    promote_mode = get_promote_mode()
+    quarantine_mode = get_quarantine_mode()
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    _object = bucket.get_blob(object_name)
+
+    result = message['scanning_result']
+    findings = result['Findings']
+    print(f'Findings: {findings}')
+
+    scan_date = time.strftime('%Y/%m/%d %H:%M:%S', time.localtime(message['timestamp']))
+    scan_result = 'malicious' if findings else 'no issues found'
+
+    operation = 'quarantine' if findings else 'promotion'
+    mode = quarantine_mode if findings else promote_mode
+    dst_bucket_name = quarantine_storage_bucket if findings else promote_storage_bucket
+
+    if not dst_bucket_name:
+        print(f'Skip: No storage connection string specified for {operation}')
+        return
+
+    codes = result['Codes']
+    code = CODE_EMPTY
+    if len(codes) > 0:
+        code = CODE_SKIP_MULTIPLE if len(codes) > 1 else codes[0]
+    fss_metadata = {
+        f'{FSS_TAG_PREFIX}scanned' : 'true',
+        f'{FSS_TAG_PREFIX}scan-date' : scan_date,
+        f'{FSS_TAG_PREFIX}scan-result' : scan_result,
+        f'{FSS_TAG_PREFIX}scan-detail-code' : str(code),
+        f'{FSS_TAG_PREFIX}scan-detail-message' : CODE_MESSAGES.get(code, CODE_MESSAGES[CODE_MISC]),
+    }
+    print(f'FSS metadata: {fss_metadata}')
+    set_object_metadata(_object, fss_metadata)
+    copy_object(storage_client, bucket_name, dst_bucket_name, _object)
+
+    if mode == 'move':
+        bucket = storage_client.bucket(bucket_name)
+        bucket.delete_blob(object_name)
+
+    print(f'File {operation} is successful (mode: {mode})')
+
+def set_object_metadata(_object, metadata):
+    """Set metadata for object."""
+    try:
+        _object.metadata = metadata
+        _object.patch()
+        print(f'Metadata: {metadata} set for {_object.name}')
+    except Exception as ex:
+        print('failed to set object metadata: ' + str(ex))
+
+def copy_object(storage_client: storage.Client, source_bucket_name: str, destination_bucket_name: str, _object):
+    try:
+        source_bucket = storage_client.bucket(source_bucket_name)
+        destination_bucket = storage_client.bucket(destination_bucket_name)
+        new_object = source_bucket.copy_blob(_object, destination_bucket)
+        print(f'Copied {_object.name} to {destination_bucket_name} as {new_object.name}')
+    except Exception as e:
+        logging.error(e)
+
+def get_mode_from_env(mode_key):
+    mode = os.environ.get(mode_key, 'move').lower()
+    return mode if mode in MODES else DEFAULT_MODE
+
+def get_promote_mode():
+    return get_mode_from_env('PROMOTE_MODE')
+
+def get_quarantine_mode():
+    return get_mode_from_env('QUARANTINE_MODE')
+
+def exclude_key_prefix(d, key_prefix):
+    if d is None:
+        return {}
+    return dict(filter(lambda elem: not elem[0].startswith(key_prefix), d.items()))

--- a/post-scan-actions/gcp-python-promote-or-quarantine/src/requirements.txt
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/src/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-storage==2.1.0

--- a/post-scan-actions/gcp-python-promote-or-quarantine/variables.tf
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/variables.tf
@@ -1,0 +1,54 @@
+variable "project_settings" {
+  type = object({
+    project_id = string
+    region = string
+    plugin_prefix = string
+  })
+  sensitive = true
+}
+
+variable "deployment_name" {
+  type = string
+  description = "The name of the deployment"
+}
+
+variable "scan_result_topic" {
+  type = string
+  description = "The name of the Pub/Sub topic for scan results topic"
+}
+
+variable "scanning_bucket" {
+  type = string
+  description = "Scanning bucket name"
+  nullable = false
+}
+
+variable "quarantine_mode" {
+  type = string
+  description = "The quarantine mode to use: 'move' or 'copy'"
+  nullable = false
+  validation {
+    condition = contains(["move", "copy"], var.quarantine_mode)
+    error_message = "Value must be one of 'move' or 'copy'."
+  }
+}
+
+variable "quarantine_bucket" {
+  type = string
+  description = "The quarantine bucket to use. Leave it empty if you don't want to quarantine files."
+}
+
+variable "promote_mode" {
+  type = string
+  description = "The promote mode to use: 'move' or 'copy'"
+  nullable = false
+  validation {
+    condition = contains(["move", "copy"], var.promote_mode)
+    error_message = "Value must be one of 'move' or 'copy'."
+  }
+}
+
+variable "promote_bucket" {
+  type = string
+  description = "The promote bucket to use. Leave it empty if you don't want to promote files."
+}


### PR DESCRIPTION
# Add GCP Promote and Quarantine Plugin

## Change Summary

Add GCP promte and quarantine plugin

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
If open in cloudshell button needed to test use [this link](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fandrew-c-lee%2Fcloudone-filestorage-plugins.git&cloudshell_workspace=post-scan-actions%2Fgcp-python-promote-or-quarantine&cloudshell_tutorial=docs/deploy-tutorial.md)