### PR TITLE
fix: fix gcp promote and quarantine role binding failed

### DIFF
--- a/post-scan-actions/gcp-python-promote-or-quarantine/README.md
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/README.md
@@ -1,7 +1,5 @@
 # Cloud One File Storage Security Post Scan Action for GCP - Promote or Quarantine
 
-**Warning: GCP solution is not yet in GA phase.**
-
 ## Prerequisites
 
 1. **Install supporting tools**

--- a/post-scan-actions/gcp-python-promote-or-quarantine/main.auto.tfvars.example
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/main.auto.tfvars.example
@@ -1,8 +1,6 @@
-project_settings = {
-    project_id = "<GCP_PROJECT_ID>" // e.g. test-project-998877
-    region = "<GCP_REGION>" // e.g. us-central1
-    plugin_prefix = "<CLOUD_FUNCTION_PREFIX>" // e.g. test-for-fss
-}
+project_id = "<GCP_PROJECT_ID>" // e.g. test-project-998877
+region = "<GCP_REGION>" // e.g. us-central1
+plugin_prefix = "<CLOUD_FUNCTION_PREFIX>" // e.g. test-for-fss
 
 deployment_name = "<DEPLOYMENT_NAME>" // e.g. test-deployment
 

--- a/post-scan-actions/gcp-python-promote-or-quarantine/variables.tf
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/variables.tf
@@ -1,10 +1,17 @@
-variable "project_settings" {
-  type = object({
-    project_id = string
-    region = string
-    plugin_prefix = string
-  })
+variable "project_id" {
+  type = string
+  description = "ID of the GCP project which the plugin will be deployed"
   sensitive = true
+}
+
+variable "region" {
+  type = string
+  description = "GCP region to deploy the plugin"
+}
+
+variable "function_perfix" {
+  type = string
+  description = "GCP function prefix to use for the plugin"
 }
 
 variable "deployment_name" {


### PR DESCRIPTION
# Fix GCP promote and quarantine role binding failed

## Change Summary

* Lock to terraform GCP version to `4.0.0`
* Extract `project_id`, `region` and `plugin_prefix` from `project_settings` so that the values can be properly set in interactive CLI.
* Add the random suffix to `titles` and `display_name` so the related resource can be more easily distinguish.
* Fix the role binding problem by reference the `name` instead of `role_id` 

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
