### PR TITLE
fix: Fix GCP plugin's variable name

### DIFF
--- a/post-scan-actions/gcp-python-promote-or-quarantine/variables.tf
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/variables.tf
@@ -9,7 +9,7 @@ variable "region" {
   description = "GCP region to deploy the plugin"
 }
 
-variable "function_perfix" {
+variable "plugin_prefix" {
   type = string
   description = "GCP function prefix to use for the plugin"
 }


### PR DESCRIPTION
# Fix 

## Change Summary

Within the file `variables.tf` the variable `function_perfix` is changed to the correct name `plugin_prefix`.

## PR Checklist

- [X] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [X] Not required
- Plugins that have versioning
  - [X] Not required
