### PR TITLE
feat: Migrates Full and Scheduled to use AWS Step Functions

### DIFF
--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/README.md
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/README.md
@@ -7,7 +7,7 @@ It deploys all the required resources to trigger a full scan, scheduled or not, 
 1. **Deploy File Storage Security**
     - Deploy FSS to desired bucket *before* deploying this stack.
 2. **Find the 'ScannerQueueArn' SQS queue ARN**
-    - In the AWS console, go to **Services** > **Amazon SQS ** > your ScannerQueue queue > **Outputs**.
+    - In the AWS console, go to **Services** > **Amazon SQS** > your ScannerQueue queue > **Outputs**.
     - locate **ScannerQueueArn** ARN.
     - Copy the **ScanResultTopic** ARN to a temporary location. Example: `arn:aws:sqs:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL`
 3. **Find the 'ScannerQueueUrl' SQS queue url**
@@ -24,7 +24,7 @@ It deploys all the required resources to trigger a full scan, scheduled or not, 
 ### From CloudFormation
 
 1. Download cloudone-filestorage-plugin-full-scan.json
-2. Visit [CloudFormation's Creat stack page](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/template)
+2. Visit [CloudFormation's Create stack page](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/template)
 3. Select `Upload a template file` and pick the downloaded template
 4. Fill in the parameters.
 5. Check the `I acknowledge that this app creates custom IAM roles.` checkbox.
@@ -39,7 +39,7 @@ It deploys all the required resources to trigger a full scan, scheduled or not, 
 
 ### Embed as a Nested App in Your Serverless Application
 
-1. Visit [the app's page on the AWS Lambda Console](https://console.aws.amazon.com/lambda/home?#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:218213273676:applications/cloudone-filestorage-plugin-trigger-full-scheduled-scan).
+1. Visit [the app's page on the AWS Lambda Console](https://console.aws.amazon.com/lambda/home?#/create/app?applicationId=arn:aws:serverlessrepo:us-east-1:415485722356:applications/cloudone-filestorage-plugin-trigger-full-scheduled-scan).
 2. Click the `Copy as SAM Resource` button and paste the copied YAML into your SAM template, filling in any required parameters.
 
 ## Running it

--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.json
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.json
@@ -1,265 +1,723 @@
 {
-  "Metadata": {
-    "AWS::ServerlessRepo::Application": {
-      "Name": "cloudone-filestorage-plugin-trigger-full-scheduled-scan",
-      "Description": "It deploys all the required resources to trigger a full scan, scheduled or not, on a S3 bucket leveraging an existing Trend Micro File Storage Security deployment.",
-      "Author": "Trend Micro Cloud One File Storage Security",
-      "SpdxLicenseId": "Apache-2.0",
-      "LicenseUrl": "../../LICENSE",
-      "ReadmeUrl": "README.md",
-      "Labels": [
-          "trendmicro",
-          "cloudone",
-          "filestorage",
-          "s3",
-          "bucket",
-          "plugin",
-          "full",
-          "full-scan",
-          "scheduled",
-          "scheduled-scan"
-      ],
-      "HomePageUrl": "https://github.com/trendmicro/cloudone-filestorage-plugins",
-      "SemanticVersion": "1.0.1",
-      "SourceCodeUrl": "https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/scan-triggers/aws-python-bucket-full-and-scheduled-scan"
-    }
+ "Parameters": {
+  "BucketName": {
+   "Type": "String",
+   "Description": "Name of a bucket that you want to full scan. Make sure you have FSS Storage Stack deployed around it already."
   },
-  "Transform": "AWS::Serverless-2016-10-31",
-  "Parameters": {
-    "BucketName": {
-      "Type": "String",
-      "Description": "Name of a bucket that you want to full scan. Make sure you have FSS Storage Stack deployed around it already."
-    },
-    "ScannerQueueArn": {
-      "Type": "String",
-      "Description": "ARN of the ScannerQueue queue. Something like arn:aws:sqs:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL"
-    },
-    "ScannerQueueUrl": {
-      "Type": "String",
-      "Description": "URL of the ScannerQueue queue. Something like https://sqs.us-east-1.amazonaws.com/123456789012/All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL"
-    },
-    "ScanResultTopicArn": {
-      "Type": "String",
-      "Description": "ARN of ScanResultTopic topic. Something like arn:aws:sns:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-StorageStack-1E00QCLBZW7M4-ScanResultTopic-1W7RZ7PBZZUJO"
-    },
-    "Schedule": {
-      "Type": "String",
-      "Default": "",
-      "Description": "Set a schedule for full scan. If empty, there will not be a scheduled scan. Defaults to empty. More info at: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html"
-    }
+  "ScannerQueueArn": {
+   "Type": "String",
+   "Description": "ARN of the ScannerQueue queue. Something like arn:aws:sqs:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL"
   },
-  "Conditions": {
-    "SetSchedule": {
-      "Fn::Not": [
+  "ScannerQueueUrl": {
+   "Type": "String",
+   "Description": "URL of the ScannerQueue queue. Something like https://sqs.us-east-1.amazonaws.com/123456789012/All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL"
+  },
+  "ScanResultTopicArn": {
+   "Type": "String",
+   "Description": "ARN of ScanResultTopic topic. Something like arn:aws:sns:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-StorageStack-1E00QCLBZW7M4-ScanResultTopic-1W7RZ7PBZZUJO"
+  },
+  "Schedule": {
+   "Type": "String",
+   "Default": "",
+   "Description": "Set a schedule for full scan. If empty, there will not be a scheduled scan. Defaults to empty. More info at: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html"
+  }
+ },
+ "Conditions": {
+  "SetSchedule": {
+   "Fn::Not": [
+    {
+     "Fn::Equals": [
+      "",
+      {
+       "Ref": "Schedule"
+      }
+     ]
+    }
+   ]
+  }
+ },
+ "Resources": {
+  "StateBucket": {
+   "Type": "AWS::S3::Bucket",
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain"
+  },
+  "PaginatorExecutionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
         {
-          "Fn::Equals": [
-            "",
-            {
-              "Ref": "Schedule"
-            }
-          ]
-        }
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
       ]
-    }
+     }
+    ]
+   }
   },
-  "Resources": {
-    "ExecutionRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com"
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition"
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-              ]
-            ]
-          }
-        ]
-      }
-    },
-    "ExecutionRoleDefaultPolicy": {
-      "Type": "AWS::IAM::Policy",
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:ListBucket",
-                "s3:ListObjectsV2"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition"
-                    },
-                    ":s3:::",
-                    {
-                      "Ref": "BucketName"
-                    }
-                  ]
-                ]
-              }
-            },
-            {
-              "Action": [
-                "s3:GetObject",
-                "s3:PutObjectTagging"
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition"
-                    },
-                    ":s3:::",
-                    {
-                      "Ref": "BucketName"
-                    },
-                    "/*"
-                  ]
-                ]
-              }
-            },
-            {
-              "Action": "sqs:SendMessage",
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "ScannerQueueArn"
-              }
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "PolicyName": "ExecutionRoleDefaultPolicy",
-        "Roles": [
-          {
-            "Ref": "ExecutionRole"
-          }
-        ]
-      }
-    },
-    "BucketFullScan": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "ZipFile": "\nimport json\nimport boto3\nfrom botocore.config import Config\nfrom botocore.exceptions import ClientError\nimport uuid\nimport os\nimport logging\nlogger = logging.getLogger()\n\nbucket=os.environ['BucketToScanName']\nsqs_url = os.environ['SQSUrl']\nsqs_region = sqs_url.split('.')[1]\nsqs_endpoint_url = 'https://sqs.{0}.amazonaws.com'.format(sqs_region)\nlogger.info('## ENVIRONMENT VARIABLES')\nlogger.info('Bucket to be fully scanned: ' + bucket)\nlogger.info('Scanner queue URL: ' + sqs_url)\nlogger.info('Scanner queue region: ' + sqs_region)\nlogger.info('Scanner queue endpoint URL: ' + sqs_endpoint_url)\nlogger.info('SNS Arn: ' + os.environ['SNSArn'])\n\n  \ndef get_matching_s3_objects(bucket, prefix=\"\", suffix=\"\"):\n  s3 = boto3.client(\"s3\")\n  paginator = s3.get_paginator(\"list_objects_v2\")\n    \n  kwargs = {'Bucket': bucket}\n    \n  # We can pass the prefix directly to the S3 API. If the user has passed\n  # a tuple or list of prefixes, we go through them one by one.\n  if isinstance(prefix, str):\n    prefixes = (prefix,)\n  else:\n    prefixes = prefix\n    \n  for key_prefix in prefixes:\n    kwargs[\"Prefix\"] = key_prefix\n    \n  for page in paginator.paginate(**kwargs):\n    try:\n      contents = page[\"Contents\"]\n    except KeyError:\n      break\n    \n    for obj in contents:\n      key = obj[\"Key\"]\n      if key.endswith(suffix):\n        yield obj\n  \n  \n  \ndef create_presigned_url(bucket_name, object_name, expiration):\n  \"\"\"Generate a presigned URL to share an S3 object\n    \n  :param bucket_name: string\n  :param object_name: string\n  :param expiration: Time in seconds for the presigned URL to remain valid\n  :return: Presigned URL as string. If error, returns None.\n  \"\"\"\n    \n  # Generate a presigned URL for the S3 object\n  s3_client = boto3.client('s3', config=Config(s3={'addressing_style': 'virtual'}, signature_version='s3v4'))\n  try:\n    response = s3_client.generate_presigned_url(\n      'get_object',\n      Params={\n      'Bucket': bucket_name,\n      'Key': object_name\n    },\n    ExpiresIn=expiration\n    )\n  except ClientError as e:\n    print('failed to generate pre-signed URL: ' + str(e))\n    return None\n    \n  # The response contains the presigned URL which is sensitive data\n  return response\n  \n\ndef push_to_sqs(bucket_name, object_name, presigned_url, event_time):\n  object = {\n    'S3': {\n    'bucket': \"{0}\".format(bucket_name),\n    'object': \"{0}\".format(object_name)\n  },\n    'ScanID': str(uuid.uuid4()),\n    'SNS' : os.environ['SNSArn'],\n    'URL': \"{0}\".format(presigned_url),\n    'ModTime': event_time\n  }\n  try:\n    session = boto3.session.Session(region_name=sqs_region)\n    sqs = session.resource(service_name='sqs', endpoint_url=sqs_endpoint_url)\n    queue = sqs.Queue(url=sqs_url)\n    response = queue.send_message(MessageBody=json.dumps(object))\n    return response\n  except ClientError as e:\n    print('failed to push SQS message: ' + str(e))\n    return None\n  \ndef handler(event, context):  \n  for object in get_matching_s3_objects(bucket=os.environ['BucketToScanName']):\n    presigned = create_presigned_url(bucket_name=bucket, object_name=object[\"Key\"], expiration=3600)\n    sqs_response = push_to_sqs(bucket, object[\"Key\"], presigned, object['LastModified'].isoformat())\n    print(sqs_response)\n  return {\n    'statusCode': 200,\n    'body': json.dumps('Manual Scan was successfully triggered.')\n  }\n      "
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "ExecutionRole",
-            "Arn"
-          ]
-        },
-        "Environment": {
-          "Variables": {
-            "SNSArn": {
-              "Ref": "ScanResultTopicArn"
-            },
-            "SQSUrl": {
-              "Ref": "ScannerQueueUrl"
-            },
-            "BucketToScanName": {
-              "Ref": "BucketName"
-            }
-          }
-        },
-        "Handler": "index.handler",
-        "Runtime": "python3.8",
-        "Timeout": 600
-      },
-      "DependsOn": [
-        "ExecutionRoleDefaultPolicy",
-        "ExecutionRole"
-      ]
-    },
-    "ScanOnSchedule": {
-      "Type": "AWS::Events::Rule",
-      "Properties": {
-        "ScheduleExpression": {
-          "Ref": "Schedule"
-        },
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "BucketFullScan",
-                "Arn"
-              ]
-            },
-            "Id": "Target0"
-          }
-        ]
-      },
-      "Condition": "SetSchedule"
-    },
-    "ScanOnScheduleAllowEventRuleFssFullScanStackBucketFullScan": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "BucketFullScan",
-            "Arn"
-          ]
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "ScanOnSchedule",
-            "Arn"
-          ]
-        }
-      },
-      "Condition": "SetSchedule"
-    }
-  },
-  "Outputs": {
-    "fullscannerlambdapage": {
-      "Value": {
+  "PaginatorExecutionRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "s3:ListBucket",
+       "Effect": "Allow",
+       "Resource": {
         "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":s3:::",
+          {
+           "Ref": "BucketName"
+          }
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "s3:Abort*",
+        "s3:DeleteObject*",
+        "s3:PutObject",
+        "s3:PutObjectLegalHold",
+        "s3:PutObjectRetention",
+        "s3:PutObjectTagging",
+        "s3:PutObjectVersionTagging"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "StateBucket",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
           "",
           [
-            "https://",
-            {
-              "Ref": "AWS::Region"
-            },
-            ".console.aws.amazon.com/lambda/home?region=",
-            {
-              "Ref": "AWS::Region"
-            },
-            "#/functions/",
-            {
-              "Ref": "BucketFullScan"
-            },
-            "?tab=code"
+           {
+            "Fn::GetAtt": [
+             "StateBucket",
+             "Arn"
+            ]
+           },
+           "/*"
           ]
-        ]
+         ]
+        }
+       ]
       }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "PaginatorExecutionRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "PaginatorExecutionRole"
+     }
+    ]
+   }
+  },
+  "PaginatorFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "const AWS = require('aws-sdk');\nconst s3 = new AWS.S3();\n\nconst STATE_BUCKET = process.env.STATE_BUCKET;\nconst KEY_WITH_KEYS_TO_SCAN ='keys';\n\nexports.lambda_handler = async (event) => {\n  console.log(event);\n  const bucket = event.bucket;\n  const allKeys = await getAllKeys(bucket);\n  const writeResult = await writeToBucket(allKeys, KEY_WITH_KEYS_TO_SCAN, STATE_BUCKET);\n\n  return {\n    bucket: bucket,\n    stateBucket: STATE_BUCKET,\n    stateKey: KEY_WITH_KEYS_TO_SCAN,\n    limit: 500\n  }\n};\n\nconst getKeysInPage = async (bucket, continuationToken) => {\n  const params = {\n    Bucket: bucket,\n    ContinuationToken: continuationToken? continuationToken : null\n  };\n  const response = await s3.listObjectsV2(params).promise();\n  return {\n    keys: response.Contents.map(object => object.Key),\n    nextContinuationToken: response.NextContinuationToken\n  };\n};\n\nconst getAllKeys = async (bucket) => {\n  let {keys, nextContinuationToken} = await getKeysInPage(bucket);\n  while (nextContinuationToken){\n    const result = await getKeysInPage(bucket, nextContinuationToken);\n    console.log(result);\n    keys.push(...result.keys);\n    nextContinuationToken = result.nextContinuationToken? result.nextContinuationToken : null;\n  }\n  return keys;\n};\n\nconst writeToBucket = async (content, key, bucket) => {\n  try {\n    const params = {\n      Bucket: bucket,\n      Key: key,\n      ContentType:'binary',\n      Body: Buffer.from(JSON.stringify(content))\n    };\n    const result = await s3.putObject(params).promise();\n    return result;\n  } catch (error) {\n    return error;\n  }\n};\n  "
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "PaginatorExecutionRole",
+      "Arn"
+     ]
+    },
+    "Architectures": [
+     "arm64"
+    ],
+    "Environment": {
+     "Variables": {
+      "STATE_BUCKET": {
+       "Ref": "StateBucket"
+      }
+     }
+    },
+    "Handler": "index.lambda_handler",
+    "MemorySize": 1024,
+    "Runtime": "nodejs16.x",
+    "Timeout": 900
+   },
+   "DependsOn": [
+    "PaginatorExecutionRoleDefaultPolicy",
+    "PaginatorExecutionRole"
+   ]
+  },
+  "FilterExecutionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "FilterExecutionRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "s3:Abort*",
+        "s3:DeleteObject*",
+        "s3:GetBucket*",
+        "s3:GetObject*",
+        "s3:List*",
+        "s3:PutObject",
+        "s3:PutObjectLegalHold",
+        "s3:PutObjectRetention",
+        "s3:PutObjectTagging",
+        "s3:PutObjectVersionTagging"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "StateBucket",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           {
+            "Fn::GetAtt": [
+             "StateBucket",
+             "Arn"
+            ]
+           },
+           "/*"
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "FilterExecutionRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "FilterExecutionRole"
+     }
+    ]
+   }
+  },
+  "FilterFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "const AWS = require('aws-sdk');\nconst s3 = new AWS.S3();\n\nconst fetchKeys = async (bucket, key) => {\n    try {\n        const params = {\n            Bucket: bucket,\n            Key: key\n        };\n        const result = await s3.getObject(params).promise();\n        const keys = JSON.parse(result.Body.toString('utf-8'));\n        return keys;\n    } catch (error) {\n        throw error;\n    }\n};\n\nconst writeToBucket = async (content, key, bucket) => {\n    try {\n      const params = {\n        Bucket: bucket,\n        Key: key,\n        ContentType:'binary',\n        Body: Buffer.from(JSON.stringify(content))\n      };\n      const result = await s3.putObject(params).promise();\n      return result;\n    } catch (error) {\n      return error;\n    }\n};\n\nconst filterKeys = (keys, limit) => {\n    const keysToScan = keys.slice(0, limit);\n    const remainingKeys = keys.slice(limit);\n    return {\n        keysToScan,\n        remainingKeys\n    };\n};\n\nexports.lambda_handler = async (event) => {\n    console.log(event);\n    const stateBucket = event.stateBucket;\n    const stateKey = event.stateKey;\n    const scanLimitPerIteration = event.limit;\n    const bucket = event.bucket;\n    const allKeys = await fetchKeys(stateBucket, stateKey);\n    \n    const filtered = filterKeys(allKeys, scanLimitPerIteration);\n    \n    // Rewrite file in bucket with remaining keys\n    if (filtered.remainingKeys){\n        await writeToBucket(filtered.remainingKeys, stateKey, stateBucket);\n    }\n\n    const response = {\n        keys: filtered.keysToScan,\n        bucket: bucket,\n        limit: scanLimitPerIteration,\n        remainingKeysLength: filtered.remainingKeys? filtered.remainingKeys.length : null,\n        stateBucket: event.stateBucket,\n        stateKey: event.stateKey\n    };\n    \n    return response;\n};\n"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "FilterExecutionRole",
+      "Arn"
+     ]
+    },
+    "Architectures": [
+     "arm64"
+    ],
+    "Environment": {
+     "Variables": {
+      "BUCKET_NAME": {
+       "Ref": "BucketName"
+      }
+     }
+    },
+    "Handler": "index.lambda_handler",
+    "MemorySize": 512,
+    "Runtime": "nodejs16.x",
+    "Timeout": 900
+   },
+   "DependsOn": [
+    "FilterExecutionRoleDefaultPolicy",
+    "FilterExecutionRole"
+   ]
+  },
+  "ScanOneObjectExecutionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "ScanOneObjectExecutionRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "s3:GetObject",
+        "s3:PutObjectTagging"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":s3:::",
+          {
+           "Ref": "BucketName"
+          },
+          "/*"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": "sqs:SendMessage",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "ScannerQueueArn"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ScanOneObjectExecutionRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "ScanOneObjectExecutionRole"
+     }
+    ]
+   }
+  },
+  "ScanOneObjectFunction": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "# Copyright (C) 2021 Trend Micro Inc. All rights reserved.\n\nimport json\nimport os\nimport logging\nimport boto3\nimport botocore\nfrom botocore.config import Config\nfrom botocore.exceptions import ClientError\nimport urllib.parse\nimport uuid\nimport datetime\n\nsqs_url = os.environ['SQSUrl']\nprint('scanner queue URL: ' + sqs_url)\nsqs_region = sqs_url.split('.')[1]\nprint('scanner queue region: ' + sqs_region)\nsqs_endpoint_url = 'https://sqs.{0}.amazonaws.com'.format(sqs_region)\nprint('scanner queue endpoint URL: ' + sqs_endpoint_url)\nreport_object_key = 'True' == os.environ.get('REPORT_OBJECT_KEY', 'False')\nprint(f'report object key: {report_object_key}')\n\nregion = boto3.session.Session().region_name\ns3_client_path = boto3.client('s3', region, config=Config(s3={'addressing_style': 'path'}, signature_version='s3v4'))\ns3_client_virtual = boto3.client('s3', region, config=Config(s3={'addressing_style': 'virtual'}, signature_version='s3v4'))\n\ntry:\n    with open('version.json') as version_file:\n        version = json.load(version_file)\n        print(f'version: {version}')\nexcept Exception as ex:\n    print('failed to get version: ' + str(ex))\n\ndef create_presigned_url(bucket_name, object_name, expiration):\n    \"\"\"Generate a presigned URL to share an S3 object\n\n    :param bucket_name: string\n    :param object_name: string\n    :param expiration: Time in seconds for the presigned URL to remain valid\n    :return: Presigned URL as string. If error, returns None.\n    \"\"\"\n\n    # Generate a presigned URL for the S3 object\n    try:\n        s3_client = s3_client_path if '.' in bucket_name else s3_client_virtual\n        response = s3_client.generate_presigned_url(\n            'get_object',\n            Params={\n                'Bucket': bucket_name,\n                'Key': object_name\n            },\n            ExpiresIn=expiration\n        )\n    except ClientError as e:\n        print('failed to generate pre-signed URL: ' + str(e))\n        return None\n\n    # The response contains the presigned URL which is sensitive data\n    return response\n\n\ndef push_to_sqs(bucket_name, object_name, amz_request_id, presigned_url, event_time):\n    object = {\n        'S3': {\n            'bucket': bucket_name,\n            'object': object_name,\n            'amzRequestID': amz_request_id,\n        },\n        'ScanID': str(uuid.uuid4()),\n        'SNS' : os.environ['SNSArn'],\n        'URL': presigned_url,\n        'ModTime': event_time,\n        'ReportObjectKey': report_object_key\n    }\n    try:\n        session = boto3.session.Session(region_name=sqs_region)\n        sqs = session.resource(service_name='sqs', endpoint_url=sqs_endpoint_url)\n        queue = sqs.Queue(url=sqs_url)\n        response = queue.send_message(MessageBody=json.dumps(object))\n        return response\n    except ClientError as e:\n        print('failed to push SQS message: ' + str(e))\n        return None\n\ndef is_folder(key):\n    return key.endswith('/')\n\ndef handle_step_functions_event(bucket, key):\n    key = urllib.parse.unquote_plus(key)\n    amz_request_id = \"f\"\n    event_time = datetime.datetime.utcnow().isoformat() # ISO-8601 format, 1970-01-01T00:00:00.000Z, when Amazon S3 finished processing the request\n\n    if is_folder(key):\n        print('Skip scanning for folder.')\n        return\n\n    presigned_url = create_presigned_url(\n        bucket,\n        key,\n        expiration = 60 * 60 # in seconds\n    )\n    print(f'AMZ request ID: {amz_request_id}, event time: {event_time}, URL:', presigned_url.split('?')[0])\n    sqs_response = push_to_sqs(bucket, key, amz_request_id, presigned_url, event_time)\n    print(sqs_response)\n\ndef lambda_handler(event, context):\n\n    bucket = event['bucket']\n    key = event['key']\n    handle_step_functions_event(bucket, key)"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "ScanOneObjectExecutionRole",
+      "Arn"
+     ]
+    },
+    "Environment": {
+     "Variables": {
+      "SNSArn": {
+       "Ref": "ScanResultTopicArn"
+      },
+      "SQSUrl": {
+       "Ref": "ScannerQueueUrl"
+      }
+     }
+    },
+    "Handler": "index.lambda_handler",
+    "MemorySize": 128,
+    "Runtime": "python3.9",
+    "Timeout": 60
+   },
+   "DependsOn": [
+    "ScanOneObjectExecutionRoleDefaultPolicy",
+    "ScanOneObjectExecutionRole"
+   ]
+  },
+  "ScanStarterExecutionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": {
+         "Fn::Join": [
+          "",
+          [
+           "states.",
+           {
+            "Ref": "AWS::Region"
+           },
+           ".amazonaws.com"
+          ]
+         ]
+        }
+       }
+      }
+     ],
+     "Version": "2012-10-17"
     }
+   }
+  },
+  "ScanStarterExecutionRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "lambda:InvokeFunction",
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::GetAtt": [
+          "FilterFunction",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::GetAtt": [
+          "ScanOneObjectFunction",
+          "Arn"
+         ]
+        }
+       ]
+      },
+      {
+       "Action": "states:StartExecution",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ScannerLoopStepFunction",
+         "Arn"
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ScanStarterExecutionRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "ScanStarterExecutionRole"
+     }
+    ]
+   }
+  },
+  "ScannerLoopStepFunction": {
+   "Type": "AWS::StepFunctions::StateMachine",
+   "Properties": {
+    "RoleArn": {
+     "Fn::GetAtt": [
+      "ScanStarterExecutionRole",
+      "Arn"
+     ]
+    },
+    "DefinitionString": {
+     "Fn::Join": [
+      "",
+      [
+       "\n      {\n        \"Comment\": \"A machine that loops trough all files a bucket to scan them with File Storage Security.\",\n        \"StartAt\": \"Filter first 1000 keys to scan\",\n        \"States\": {\n          \"Filter first 1000 keys to scan\": {\n            \"Type\": \"Task\",\n            \"Resource\": \"arn:aws:states:::lambda:invoke\",\n            \"OutputPath\": \"$.Payload\",\n            \"Parameters\": {\n              \"Payload.$\": \"$\",\n              \"FunctionName\": \"",
+       {
+        "Fn::GetAtt": [
+         "FilterFunction",
+         "Arn"
+        ]
+       },
+       "\"\n            },\n            \"Retry\": [\n              {\n                \"ErrorEquals\": [\n                  \"Lambda.ServiceException\",\n                  \"Lambda.AWSLambdaException\",\n                  \"Lambda.SdkClientException\"\n                ],\n                \"IntervalSeconds\": 2,\n                \"MaxAttempts\": 6,\n                \"BackoffRate\": 2\n              }\n            ],\n            \"Next\": \"Parallel\"\n          },\n          \"Parallel\": {\n            \"Type\": \"Parallel\",\n            \"Branches\": [\n              {\n                \"StartAt\": \"Map\",\n                \"States\": {\n                  \"Map\": {\n                    \"Type\": \"Map\",\n                    \"End\": true,\n                    \"Parameters\": {\n                      \"key.$\": \"$$.Map.Item.Value\",\n                      \"bucket.$\": \"$.bucket\"\n                    },\n                    \"Iterator\": {\n                      \"StartAt\": \"Scan a Object\",\n                      \"States\": {\n                        \"Scan a Object\": {\n                          \"Type\": \"Task\",\n                          \"Resource\": \"arn:aws:states:::lambda:invoke\",\n                          \"OutputPath\": \"$.Payload\",\n                          \"Parameters\": {\n                            \"Payload.$\": \"$\",\n                            \"FunctionName\": \"",
+       {
+        "Fn::GetAtt": [
+         "ScanOneObjectFunction",
+         "Arn"
+        ]
+       },
+       "\"\n                          },\n                          \"Retry\": [\n                            {\n                              \"ErrorEquals\": [\n                                \"Lambda.ServiceException\",\n                                \"Lambda.AWSLambdaException\",\n                                \"Lambda.SdkClientException\"\n                              ],\n                              \"IntervalSeconds\": 2,\n                              \"MaxAttempts\": 6,\n                              \"BackoffRate\": 2\n                            }\n                          ],\n                          \"End\": true\n                        }\n                      }\n                    },\n                    \"ItemsPath\": \"$.keys\"\n                  }\n                }\n              },\n              {\n                \"StartAt\": \"Are there keys left?\",\n                \"States\": {\n                  \"Are there keys left?\": {\n                    \"Type\": \"Choice\",\n                    \"Choices\": [\n                      {\n                        \"Variable\": \"$.remainingKeysLength\",\n                        \"NumericGreaterThan\": 0,\n                        \"Comment\": \"Yes\",\n                        \"Next\": \"Re-execute with the remaining keys.\"\n                      }\n                    ],\n                    \"Default\": \"Pass\"\n                  },\n                  \"Re-execute with the remaining keys.\": {\n                    \"Type\": \"Task\",\n                    \"Resource\": \"arn:aws:states:::states:startExecution\",\n                    \"Parameters\": {\n                      \"StateMachineArn\": \"arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":states:",
+       {
+        "Ref": "AWS::Region"
+       },
+       ":",
+       {
+        "Ref": "AWS::AccountId"
+       },
+       ":stateMachine:ScannerLoopStateMachine\",\n                      \"Input\": {\n                        \"stateBucket.$\": \"$.stateBucket\",\n                        \"stateKey.$\": \"$.stateKey\",\n                        \"limit.$\": \"$.limit\",\n                        \"bucket.$\": \"$.bucket\",\n                        \"AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$\": \"$$.Execution.Id\"\n                      }\n                    },\n                    \"End\": true\n                  },\n                  \"Pass\": {\n                    \"Type\": \"Pass\",\n                    \"End\": true,\n                    \"Result\": {}\n                  }\n                }\n              }\n            ],\n            \"End\": true\n          }\n        }\n      }\n      "
+      ]
+     ]
+    },
+    "StateMachineName": "ScannerLoopStateMachine"
+   }
+  },
+  "FullScanStarterExecutionRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": {
+         "Fn::Join": [
+          "",
+          [
+           "states.",
+           {
+            "Ref": "AWS::Region"
+           },
+           ".amazonaws.com"
+          ]
+         ]
+        }
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "FullScanStarterExecutionRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "lambda:InvokeFunction",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "PaginatorFunction",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": "states:StartExecution",
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "ScannerLoopStepFunction",
+         "Arn"
+        ]
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "FullScanStarterExecutionRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "FullScanStarterExecutionRole"
+     }
+    ]
+   }
+  },
+  "FullScanStarterLoopStepFunction": {
+   "Type": "AWS::StepFunctions::StateMachine",
+   "Properties": {
+    "RoleArn": {
+     "Fn::GetAtt": [
+      "FullScanStarterExecutionRole",
+      "Arn"
+     ]
+    },
+    "DefinitionString": {
+     "Fn::Join": [
+      "",
+      [
+       "\n      {\n        \"Comment\": \"Kicks of a Full Scan using File Storage Security.\",\n        \"StartAt\": \"List all keys in bucket\",\n        \"States\": {\n          \"List all keys in bucket\": {\n            \"Type\": \"Task\",\n            \"Resource\": \"arn:aws:states:::lambda:invoke\",\n            \"OutputPath\": \"$.Payload\",\n            \"Parameters\": {\n              \"FunctionName\": \"",
+       {
+        "Fn::GetAtt": [
+         "PaginatorFunction",
+         "Arn"
+        ]
+       },
+       "\",\n              \"Payload\": {\n                \"bucket\": \"",
+       {
+        "Ref": "BucketName"
+       },
+       "\"\n              }\n            },\n            \"Retry\": [\n              {\n                \"ErrorEquals\": [\n                  \"Lambda.ServiceException\",\n                  \"Lambda.AWSLambdaException\",\n                  \"Lambda.SdkClientException\"\n                ],\n                \"IntervalSeconds\": 2,\n                \"MaxAttempts\": 6,\n                \"BackoffRate\": 2\n              }\n            ],\n            \"Next\": \"Start Scanner Flow\"\n          },\n          \"Start Scanner Flow\": {\n            \"Type\": \"Task\",\n            \"Resource\": \"arn:aws:states:::states:startExecution\",\n            \"Parameters\": {\n              \"StateMachineArn\": \"",
+       {
+        "Fn::GetAtt": [
+         "ScannerLoopStepFunction",
+         "Arn"
+        ]
+       },
+       "\",\n              \"Input\": {\n                \"stateKey.$\": \"$.stateKey\",\n                \"bucket.$\": \"$.bucket\",\n                \"stateBucket.$\": \"$.stateBucket\",\n                \"limit.$\": \"$.limit\",\n                \"AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$\": \"$$.Execution.Id\"\n              }\n            },\n            \"End\": true\n          }\n        }\n      }\n      "
+      ]
+     ]
+    },
+    "StateMachineName": "fullScanStarterStateMachine"
+   },
+   "DependsOn": [
+    "FullScanStarterExecutionRoleDefaultPolicy",
+    "FullScanStarterExecutionRole"
+   ]
+  },
+  "FullScanStarterLoopStepFunctionEventsRole": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "events.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    }
+   }
+  },
+  "FullScanStarterLoopStepFunctionEventsRoleDefaultPolicy": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": "states:StartExecution",
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "FullScanStarterLoopStepFunction"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "FullScanStarterLoopStepFunctionEventsRoleDefaultPolicy",
+    "Roles": [
+     {
+      "Ref": "FullScanStarterLoopStepFunctionEventsRole"
+     }
+    ]
+   }
+  },
+  "ScanOnSchedule": {
+   "Type": "AWS::Events::Rule",
+   "Properties": {
+    "ScheduleExpression": {
+     "Ref": "Schedule"
+    },
+    "State": "ENABLED",
+    "Targets": [
+     {
+      "Arn": {
+       "Ref": "FullScanStarterLoopStepFunction"
+      },
+      "Id": "Target0",
+      "RoleArn": {
+       "Fn::GetAtt": [
+        "FullScanStarterLoopStepFunctionEventsRole",
+        "Arn"
+       ]
+      }
+     }
+    ]
+   },
+   "Condition": "SetSchedule"
   }
+ },
+ "Outputs": {
+  "FullScanFunctionPage": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "AWS::Region"
+      },
+      ".console.aws.amazon.com/states/home?region=",
+      {
+       "Ref": "AWS::Region"
+      },
+      "#/statemachines/view/arn:",
+      {
+       "Ref": "AWS::Partition"
+      },
+      ":states:",
+      {
+       "Ref": "AWS::Region"
+      },
+      ":",
+      {
+       "Ref": "AWS::AccountId"
+      },
+      ":stateMachine:fullScanStarterStateMachine"
+     ]
+    ]
+   }
+  }
+ }
 }

--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
@@ -1,0 +1,902 @@
+Parameters:
+  BucketName:
+    Type: String
+    Description: Name of a bucket that you want to full scan. Make sure you have FSS Storage Stack deployed around it already.
+  ScannerQueueArn:
+    Type: String
+    Description: ARN of the ScannerQueue queue. Something like arn:aws:sqs:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL
+  ScannerQueueUrl:
+    Type: String
+    Description: URL of the ScannerQueue queue. Something like https://sqs.us-east-1.amazonaws.com/123456789012/All-in-one-TM-FileStorageSecurity-ScannerStack-IT1V5O-ScannerQueue-1IOQHTGGGZYFL
+  ScanResultTopicArn:
+    Type: String
+    Description: ARN of ScanResultTopic topic. Something like arn:aws:sns:us-east-1:123456789012:All-in-one-TM-FileStorageSecurity-StorageStack-1E00QCLBZW7M4-ScanResultTopic-1W7RZ7PBZZUJO
+  Schedule:
+    Type: String
+    Default: ""
+    Description: "Set a schedule for full scan. If empty, there will not be a scheduled scan. Defaults to empty. More info at: https://docs.aws.amazon.com/lambda/latest/dg/services-cloudwatchevents-expressions.html"
+Conditions:
+  SetSchedule:
+    Fn::Not:
+      - Fn::Equals:
+          - ""
+          - Ref: Schedule
+Resources:
+  StateBucket:
+    Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  PaginatorExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  PaginatorExecutionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: s3:ListBucket
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":s3:::"
+                  - Ref: BucketName
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:PutObject
+              - s3:PutObjectLegalHold
+              - s3:PutObjectRetention
+              - s3:PutObjectTagging
+              - s3:PutObjectVersionTagging
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - StateBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - StateBucket
+                        - Arn
+                    - /*
+        Version: "2012-10-17"
+      PolicyName: PaginatorExecutionRoleDefaultPolicy
+      Roles:
+        - Ref: PaginatorExecutionRole
+  PaginatorFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: "const AWS = require('aws-sdk');
+
+          const s3 = new AWS.S3();
+
+
+          const STATE_BUCKET = process.env.STATE_BUCKET;
+
+          const KEY_WITH_KEYS_TO_SCAN ='keys';
+
+
+          exports.lambda_handler = async (event) => {
+
+          \  console.log(event);
+
+          \  const bucket = event.bucket;
+
+          \  const allKeys = await getAllKeys(bucket);
+
+          \  const writeResult = await writeToBucket(allKeys, KEY_WITH_KEYS_TO_SCAN, STATE_BUCKET);
+
+
+          \  return {
+
+          \    bucket: bucket,
+
+          \    stateBucket: STATE_BUCKET,
+
+          \    stateKey: KEY_WITH_KEYS_TO_SCAN,
+
+          \    limit: 500
+
+          \  }
+
+          };
+
+
+          const getKeysInPage = async (bucket, continuationToken) => {
+
+          \  const params = {
+
+          \    Bucket: bucket,
+
+          \    ContinuationToken: continuationToken? continuationToken : null
+
+          \  };
+
+          \  const response = await s3.listObjectsV2(params).promise();
+
+          \  return {
+
+          \    keys: response.Contents.map(object => object.Key),
+
+          \    nextContinuationToken: response.NextContinuationToken
+
+          \  };
+
+          };
+
+
+          const getAllKeys = async (bucket) => {
+
+          \  let {keys, nextContinuationToken} = await getKeysInPage(bucket);
+
+          \  while (nextContinuationToken){
+
+          \    const result = await getKeysInPage(bucket, nextContinuationToken);
+
+          \    console.log(result);
+
+          \    keys.push(...result.keys);
+
+          \    nextContinuationToken = result.nextContinuationToken? result.nextContinuationToken : null;
+
+          \  }
+
+          \  return keys;
+
+          };
+
+
+          const writeToBucket = async (content, key, bucket) => {
+
+          \  try {
+
+          \    const params = {
+
+          \      Bucket: bucket,
+
+          \      Key: key,
+
+          \      ContentType:'binary',
+
+          \      Body: Buffer.from(JSON.stringify(content))
+
+          \    };
+
+          \    const result = await s3.putObject(params).promise();
+
+          \    return result;
+
+          \  } catch (error) {
+
+          \    return error;
+
+          \  }
+
+          };
+
+          \  "
+      Role:
+        Fn::GetAtt:
+          - PaginatorExecutionRole
+          - Arn
+      Architectures:
+        - arm64
+      Environment:
+        Variables:
+          STATE_BUCKET:
+            Ref: StateBucket
+      Handler: index.lambda_handler
+      MemorySize: 1024
+      Runtime: nodejs16.x
+      Timeout: 900
+    DependsOn:
+      - PaginatorExecutionRoleDefaultPolicy
+      - PaginatorExecutionRole
+  FilterExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  FilterExecutionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:Abort*
+              - s3:DeleteObject*
+              - s3:GetBucket*
+              - s3:GetObject*
+              - s3:List*
+              - s3:PutObject
+              - s3:PutObjectLegalHold
+              - s3:PutObjectRetention
+              - s3:PutObjectTagging
+              - s3:PutObjectVersionTagging
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - StateBucket
+                  - Arn
+              - Fn::Join:
+                  - ""
+                  - - Fn::GetAtt:
+                        - StateBucket
+                        - Arn
+                    - /*
+        Version: "2012-10-17"
+      PolicyName: FilterExecutionRoleDefaultPolicy
+      Roles:
+        - Ref: FilterExecutionRole
+  FilterFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |
+          const AWS = require('aws-sdk');
+          const s3 = new AWS.S3();
+
+          const fetchKeys = async (bucket, key) => {
+              try {
+                  const params = {
+                      Bucket: bucket,
+                      Key: key
+                  };
+                  const result = await s3.getObject(params).promise();
+                  const keys = JSON.parse(result.Body.toString('utf-8'));
+                  return keys;
+              } catch (error) {
+                  throw error;
+              }
+          };
+
+          const writeToBucket = async (content, key, bucket) => {
+              try {
+                const params = {
+                  Bucket: bucket,
+                  Key: key,
+                  ContentType:'binary',
+                  Body: Buffer.from(JSON.stringify(content))
+                };
+                const result = await s3.putObject(params).promise();
+                return result;
+              } catch (error) {
+                return error;
+              }
+          };
+
+          const filterKeys = (keys, limit) => {
+              const keysToScan = keys.slice(0, limit);
+              const remainingKeys = keys.slice(limit);
+              return {
+                  keysToScan,
+                  remainingKeys
+              };
+          };
+
+          exports.lambda_handler = async (event) => {
+              console.log(event);
+              const stateBucket = event.stateBucket;
+              const stateKey = event.stateKey;
+              const scanLimitPerIteration = event.limit;
+              const bucket = event.bucket;
+              const allKeys = await fetchKeys(stateBucket, stateKey);
+              
+              const filtered = filterKeys(allKeys, scanLimitPerIteration);
+              
+              // Rewrite file in bucket with remaining keys
+              if (filtered.remainingKeys){
+                  await writeToBucket(filtered.remainingKeys, stateKey, stateBucket);
+              }
+
+              const response = {
+                  keys: filtered.keysToScan,
+                  bucket: bucket,
+                  limit: scanLimitPerIteration,
+                  remainingKeysLength: filtered.remainingKeys? filtered.remainingKeys.length : null,
+                  stateBucket: event.stateBucket,
+                  stateKey: event.stateKey
+              };
+              
+              return response;
+          };
+      Role:
+        Fn::GetAtt:
+          - FilterExecutionRole
+          - Arn
+      Architectures:
+        - arm64
+      Environment:
+        Variables:
+          BUCKET_NAME:
+            Ref: BucketName
+      Handler: index.lambda_handler
+      MemorySize: 512
+      Runtime: nodejs16.x
+      Timeout: 900
+    DependsOn:
+      - FilterExecutionRoleDefaultPolicy
+      - FilterExecutionRole
+  ScanOneObjectExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Join:
+            - ""
+            - - "arn:"
+              - Ref: AWS::Partition
+              - :iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  ScanOneObjectExecutionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:GetObject
+              - s3:PutObjectTagging
+            Effect: Allow
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:"
+                  - Ref: AWS::Partition
+                  - ":s3:::"
+                  - Ref: BucketName
+                  - /*
+          - Action: sqs:SendMessage
+            Effect: Allow
+            Resource:
+              Ref: ScannerQueueArn
+        Version: "2012-10-17"
+      PolicyName: ScanOneObjectExecutionRoleDefaultPolicy
+      Roles:
+        - Ref: ScanOneObjectExecutionRole
+  ScanOneObjectFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: |-
+          # Copyright (C) 2021 Trend Micro Inc. All rights reserved.
+
+          import json
+          import os
+          import logging
+          import boto3
+          import botocore
+          from botocore.config import Config
+          from botocore.exceptions import ClientError
+          import urllib.parse
+          import uuid
+          import datetime
+
+          sqs_url = os.environ['SQSUrl']
+          print('scanner queue URL: ' + sqs_url)
+          sqs_region = sqs_url.split('.')[1]
+          print('scanner queue region: ' + sqs_region)
+          sqs_endpoint_url = 'https://sqs.{0}.amazonaws.com'.format(sqs_region)
+          print('scanner queue endpoint URL: ' + sqs_endpoint_url)
+          report_object_key = 'True' == os.environ.get('REPORT_OBJECT_KEY', 'False')
+          print(f'report object key: {report_object_key}')
+
+          region = boto3.session.Session().region_name
+          s3_client_path = boto3.client('s3', region, config=Config(s3={'addressing_style': 'path'}, signature_version='s3v4'))
+          s3_client_virtual = boto3.client('s3', region, config=Config(s3={'addressing_style': 'virtual'}, signature_version='s3v4'))
+
+          try:
+              with open('version.json') as version_file:
+                  version = json.load(version_file)
+                  print(f'version: {version}')
+          except Exception as ex:
+              print('failed to get version: ' + str(ex))
+
+          def create_presigned_url(bucket_name, object_name, expiration):
+              """Generate a presigned URL to share an S3 object
+
+              :param bucket_name: string
+              :param object_name: string
+              :param expiration: Time in seconds for the presigned URL to remain valid
+              :return: Presigned URL as string. If error, returns None.
+              """
+
+              # Generate a presigned URL for the S3 object
+              try:
+                  s3_client = s3_client_path if '.' in bucket_name else s3_client_virtual
+                  response = s3_client.generate_presigned_url(
+                      'get_object',
+                      Params={
+                          'Bucket': bucket_name,
+                          'Key': object_name
+                      },
+                      ExpiresIn=expiration
+                  )
+              except ClientError as e:
+                  print('failed to generate pre-signed URL: ' + str(e))
+                  return None
+
+              # The response contains the presigned URL which is sensitive data
+              return response
+
+
+          def push_to_sqs(bucket_name, object_name, amz_request_id, presigned_url, event_time):
+              object = {
+                  'S3': {
+                      'bucket': bucket_name,
+                      'object': object_name,
+                      'amzRequestID': amz_request_id,
+                  },
+                  'ScanID': str(uuid.uuid4()),
+                  'SNS' : os.environ['SNSArn'],
+                  'URL': presigned_url,
+                  'ModTime': event_time,
+                  'ReportObjectKey': report_object_key
+              }
+              try:
+                  session = boto3.session.Session(region_name=sqs_region)
+                  sqs = session.resource(service_name='sqs', endpoint_url=sqs_endpoint_url)
+                  queue = sqs.Queue(url=sqs_url)
+                  response = queue.send_message(MessageBody=json.dumps(object))
+                  return response
+              except ClientError as e:
+                  print('failed to push SQS message: ' + str(e))
+                  return None
+
+          def is_folder(key):
+              return key.endswith('/')
+
+          def handle_step_functions_event(bucket, key):
+              key = urllib.parse.unquote_plus(key)
+              amz_request_id = "f"
+              event_time = datetime.datetime.utcnow().isoformat() # ISO-8601 format, 1970-01-01T00:00:00.000Z, when Amazon S3 finished processing the request
+
+              if is_folder(key):
+                  print('Skip scanning for folder.')
+                  return
+
+              presigned_url = create_presigned_url(
+                  bucket,
+                  key,
+                  expiration = 60 * 60 # in seconds
+              )
+              print(f'AMZ request ID: {amz_request_id}, event time: {event_time}, URL:', presigned_url.split('?')[0])
+              sqs_response = push_to_sqs(bucket, key, amz_request_id, presigned_url, event_time)
+              print(sqs_response)
+
+          def lambda_handler(event, context):
+
+              bucket = event['bucket']
+              key = event['key']
+              handle_step_functions_event(bucket, key)
+      Role:
+        Fn::GetAtt:
+          - ScanOneObjectExecutionRole
+          - Arn
+      Environment:
+        Variables:
+          SNSArn:
+            Ref: ScanResultTopicArn
+          SQSUrl:
+            Ref: ScannerQueueUrl
+      Handler: index.lambda_handler
+      MemorySize: 128
+      Runtime: python3.9
+      Timeout: 60
+    DependsOn:
+      - ScanOneObjectExecutionRoleDefaultPolicy
+      - ScanOneObjectExecutionRole
+  ScanStarterExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::Join:
+                  - ""
+                  - - states.
+                    - Ref: AWS::Region
+                    - .amazonaws.com
+        Version: "2012-10-17"
+  ScanStarterExecutionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: lambda:InvokeFunction
+            Effect: Allow
+            Resource:
+              - Fn::GetAtt:
+                  - FilterFunction
+                  - Arn
+              - Fn::GetAtt:
+                  - ScanOneObjectFunction
+                  - Arn
+          - Action: states:StartExecution
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - ScannerLoopStepFunction
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: ScanStarterExecutionRoleDefaultPolicy
+      Roles:
+        - Ref: ScanStarterExecutionRole
+  ScannerLoopStepFunction:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - ScanStarterExecutionRole
+          - Arn
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - |-2
+              
+                    {
+                      "Comment": "A machine that loops trough all files a bucket to scan them with File Storage Security.",
+                      "StartAt": "Filter first 1000 keys to scan",
+                      "States": {
+                        "Filter first 1000 keys to scan": {
+                          "Type": "Task",
+                          "Resource": "arn:aws:states:::lambda:invoke",
+                          "OutputPath": "$.Payload",
+                          "Parameters": {
+                            "Payload.$": "$",
+                            "FunctionName": "
+            - Fn::GetAtt:
+                - FilterFunction
+                - Arn
+            - |-
+              "
+                          },
+                          "Retry": [
+                            {
+                              "ErrorEquals": [
+                                "Lambda.ServiceException",
+                                "Lambda.AWSLambdaException",
+                                "Lambda.SdkClientException"
+                              ],
+                              "IntervalSeconds": 2,
+                              "MaxAttempts": 6,
+                              "BackoffRate": 2
+                            }
+                          ],
+                          "Next": "Parallel"
+                        },
+                        "Parallel": {
+                          "Type": "Parallel",
+                          "Branches": [
+                            {
+                              "StartAt": "Map",
+                              "States": {
+                                "Map": {
+                                  "Type": "Map",
+                                  "End": true,
+                                  "Parameters": {
+                                    "key.$": "$$.Map.Item.Value",
+                                    "bucket.$": "$.bucket"
+                                  },
+                                  "Iterator": {
+                                    "StartAt": "Scan a Object",
+                                    "States": {
+                                      "Scan a Object": {
+                                        "Type": "Task",
+                                        "Resource": "arn:aws:states:::lambda:invoke",
+                                        "OutputPath": "$.Payload",
+                                        "Parameters": {
+                                          "Payload.$": "$",
+                                          "FunctionName": "
+            - Fn::GetAtt:
+                - ScanOneObjectFunction
+                - Arn
+            - |-
+              "
+                                        },
+                                        "Retry": [
+                                          {
+                                            "ErrorEquals": [
+                                              "Lambda.ServiceException",
+                                              "Lambda.AWSLambdaException",
+                                              "Lambda.SdkClientException"
+                                            ],
+                                            "IntervalSeconds": 2,
+                                            "MaxAttempts": 6,
+                                            "BackoffRate": 2
+                                          }
+                                        ],
+                                        "End": true
+                                      }
+                                    }
+                                  },
+                                  "ItemsPath": "$.keys"
+                                }
+                              }
+                            },
+                            {
+                              "StartAt": "Are there keys left?",
+                              "States": {
+                                "Are there keys left?": {
+                                  "Type": "Choice",
+                                  "Choices": [
+                                    {
+                                      "Variable": "$.remainingKeysLength",
+                                      "NumericGreaterThan": 0,
+                                      "Comment": "Yes",
+                                      "Next": "Re-execute with the remaining keys."
+                                    }
+                                  ],
+                                  "Default": "Pass"
+                                },
+                                "Re-execute with the remaining keys.": {
+                                  "Type": "Task",
+                                  "Resource": "arn:aws:states:::states:startExecution",
+                                  "Parameters": {
+                                    "StateMachineArn": "arn:
+            - Ref: AWS::Partition
+            - ":states:"
+            - Ref: AWS::Region
+            - ":"
+            - Ref: AWS::AccountId
+            - ":stateMachine:ScannerLoopStateMachine\",
+
+              \                      \"Input\": {
+
+              \                        \"stateBucket.$\": \"$.stateBucket\",
+
+              \                        \"stateKey.$\": \"$.stateKey\",
+
+              \                        \"limit.$\": \"$.limit\",
+
+              \                        \"bucket.$\": \"$.bucket\",
+
+              \                        \"AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$\": \"$$.Execution.Id\"
+
+              \                      }
+
+              \                    },
+
+              \                    \"End\": true
+
+              \                  },
+
+              \                  \"Pass\": {
+
+              \                    \"Type\": \"Pass\",
+
+              \                    \"End\": true,
+
+              \                    \"Result\": {}
+
+              \                  }
+
+              \                }
+
+              \              }
+
+              \            ],
+
+              \            \"End\": true
+
+              \          }
+
+              \        }
+
+              \      }
+
+              \      "
+      StateMachineName: ScannerLoopStateMachine
+  FullScanStarterExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                Fn::Join:
+                  - ""
+                  - - states.
+                    - Ref: AWS::Region
+                    - .amazonaws.com
+        Version: "2012-10-17"
+  FullScanStarterExecutionRoleDefaultPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: lambda:InvokeFunction
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - PaginatorFunction
+                - Arn
+          - Action: states:StartExecution
+            Effect: Allow
+            Resource:
+              Fn::GetAtt:
+                - ScannerLoopStepFunction
+                - Arn
+        Version: "2012-10-17"
+      PolicyName: FullScanStarterExecutionRoleDefaultPolicy
+      Roles:
+        - Ref: FullScanStarterExecutionRole
+  FullScanStarterLoopStepFunction:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn:
+        Fn::GetAtt:
+          - FullScanStarterExecutionRole
+          - Arn
+      DefinitionString:
+        Fn::Join:
+          - ""
+          - - |-2
+              
+                    {
+                      "Comment": "Kicks of a Full Scan using File Storage Security.",
+                      "StartAt": "List all keys in bucket",
+                      "States": {
+                        "List all keys in bucket": {
+                          "Type": "Task",
+                          "Resource": "arn:aws:states:::lambda:invoke",
+                          "OutputPath": "$.Payload",
+                          "Parameters": {
+                            "FunctionName": "
+            - Fn::GetAtt:
+                - PaginatorFunction
+                - Arn
+            - |-
+              ",
+                            "Payload": {
+                              "bucket": "
+            - Ref: BucketName
+            - |-
+              "
+                            }
+                          },
+                          "Retry": [
+                            {
+                              "ErrorEquals": [
+                                "Lambda.ServiceException",
+                                "Lambda.AWSLambdaException",
+                                "Lambda.SdkClientException"
+                              ],
+                              "IntervalSeconds": 2,
+                              "MaxAttempts": 6,
+                              "BackoffRate": 2
+                            }
+                          ],
+                          "Next": "Start Scanner Flow"
+                        },
+                        "Start Scanner Flow": {
+                          "Type": "Task",
+                          "Resource": "arn:aws:states:::states:startExecution",
+                          "Parameters": {
+                            "StateMachineArn": "
+            - Fn::GetAtt:
+                - ScannerLoopStepFunction
+                - Arn
+            - "\",
+
+              \              \"Input\": {
+
+              \                \"stateKey.$\": \"$.stateKey\",
+
+              \                \"bucket.$\": \"$.bucket\",
+
+              \                \"stateBucket.$\": \"$.stateBucket\",
+
+              \                \"limit.$\": \"$.limit\",
+
+              \                \"AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$\": \"$$.Execution.Id\"
+
+              \              }
+
+              \            },
+
+              \            \"End\": true
+
+              \          }
+
+              \        }
+
+              \      }
+
+              \      "
+      StateMachineName: fullScanStarterStateMachine
+    DependsOn:
+      - FullScanStarterExecutionRoleDefaultPolicy
+      - FullScanStarterExecutionRole
+  FullScanStarterLoopStepFunctionEventsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+        Version: "2012-10-17"
+  FullScanStarterLoopStepFunctionEventsRoleDefaultPolicy822C2937:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: states:StartExecution
+            Effect: Allow
+            Resource:
+              Ref: FullScanStarterLoopStepFunction
+        Version: "2012-10-17"
+      PolicyName: FullScanStarterLoopStepFunctionEventsRoleDefaultPolicy822C2937
+      Roles:
+        - Ref: FullScanStarterLoopStepFunctionEventsRole
+  ScanOnSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      ScheduleExpression:
+        Ref: Schedule
+      State: ENABLED
+      Targets:
+        - Arn:
+            Ref: FullScanStarterLoopStepFunction
+          Id: Target0
+          RoleArn:
+            Fn::GetAtt:
+              - FullScanStarterLoopStepFunctionEventsRole
+              - Arn
+    Condition: SetSchedule
+Outputs:
+  FullScanFunctionPage:
+    Value:
+      Fn::Join:
+        - ""
+        - - https://
+          - Ref: AWS::Region
+          - .console.aws.amazon.com/states/home?region=
+          - Ref: AWS::Region
+          - "#/statemachines/view/arn:"
+          - Ref: AWS::Partition
+          - ":states:"
+          - Ref: AWS::Region
+          - ":"
+          - Ref: AWS::AccountId
+          - :stateMachine:fullScanStarterStateMachine
+


### PR DESCRIPTION
# feat: Migrates Full and Scheduled to use AWS Step Functions

## Change Summary

The current Full and Scheduled Scan approach is flawed for buckets that have at least thousands of files as it fails to finish scanning before the AWS Lambda Function times out. This PR merges the plugin to use AWS Step Functions in order to get the job done.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [x] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] Not required

## Other Notes

Do you want to read about my saga to get this fixed?
[Here](https://awstip.com/how-to-use-and-not-use-aws-step-functions-9fe6a93fa59e) and [here](https://raphabot.medium.com/how-to-hit-aws-step-functions-limitations-b4c413da10e4).
