### PR TITLE
feat: Switch gcp promote quarantine source to terraform archive

### DIFF
--- a/post-scan-actions/gcp-python-promote-or-quarantine/Makefile
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/Makefile
@@ -1,5 +1,0 @@
-SRC_DIR = $(CURDIR)/src
-PLUGIN_ZIP_NAME = gcp-promote-and-quarantine-plugin.zip
-
-build:
-	cd $(SRC_DIR) && zip $(CURDIR)/$(PLUGIN_ZIP_NAME) *.py requirements.txt

--- a/post-scan-actions/gcp-python-promote-or-quarantine/README.md
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/README.md
@@ -20,12 +20,6 @@
    gcloud init
    ```
 
-1. Create a function zip for the deployment using make.
-
-   ```sh
-   make
-   ```
-
 1. Initialize terraform.
 
    ```sh

--- a/post-scan-actions/gcp-python-promote-or-quarantine/docs/deploy-tutorial.md
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/docs/deploy-tutorial.md
@@ -18,12 +18,6 @@ gcloud config set project <walkthrough-project-id/>
 
 ## Deploy promote and quarantine function
 
-1. Create a function zip for the deployment using make.
-
-    ```sh
-    make
-    ```
-
 1. Initialize terraform.
 
     ```sh


### PR DESCRIPTION
# feat: Switch GCP promote quarantine source to terraform archive

## Change Summary

Using terraform archive to pack function zip instead of using `make`.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
