### PR TITLE
fix: Add Cloud One Regions and Endpoints

### DIFF
--- a/post-scan-actions/aws-python-conformity-custom-check/handler.py
+++ b/post-scan-actions/aws-python-conformity-custom-check/handler.py
@@ -8,7 +8,7 @@ import urllib3
 
 http = urllib3.PoolManager()
 
-region = os.environ.get("CC_REGION", "us-west-2")
+region = os.environ.get("CC_REGION", "us-1")
 ccsecretsarn = os.environ["CC_API_SECRETS_ARN"]
 customcheckid = os.environ.get("CC_CUSTOMCHECKID", "CUSTOM-001").upper()
 customchecksev = os.environ.get("CC_CHECKSEV", "VERY_HIGH").upper()
@@ -24,7 +24,7 @@ headers = {
 
 
 def get_cc_accountid(awsaccountid):
-    accountsapi = f"https://{region}-api.cloudconformity.com/v1/accounts"
+    accountsapi = f"https://conformity.{region}.cloudone.trendmicro.com/api/accounts"
     r = http.request("GET", accountsapi, headers=headers)
     accounts = json.loads(r.data.decode("utf-8"))["data"]
     for account in accounts:
@@ -141,7 +141,7 @@ def lambda_handler(event, context):
                 }
 
                 bodyencoded = json.dumps(checksdata).encode("utf-8")
-                checksapi = f"https://{region}-api.cloudconformity.com/v1/checks"
+                checksapi = f"https://conformity.{region}.cloudone.trendmicro.com/api/checks"
 
                 r = http.request("POST", checksapi, body=bodyencoded, headers=headers)
                 print(r.data.decode("utf-8"))

--- a/post-scan-actions/aws-python-conformity-custom-check/template.yml
+++ b/post-scan-actions/aws-python-conformity-custom-check/template.yml
@@ -21,12 +21,17 @@ Parameters:
     Description: ARN of the File Storage SNS Topic to subscribe this function.
   ConformityRegion:
     Type: String
-    Description: Region where you conformity account is hosted. (us-west-2 for Cloud One customers)
-    Default: us-west-2
+    Description: Region where you conformity account is hosted.
+    Default: us-1
     AllowedValues:
-      - us-west-2
-      - ap-southeast-2
-      - eu-west-1
+      - us-1
+      - au-1
+      - gb-1
+      - in-1
+      - sg-1
+      - jp-1
+      - ca-1
+      - de-1
   ConformityApiKey:
     Type: String
     NoEcho: true


### PR DESCRIPTION
# Add Cloud One Regions and Endpoints

## Change Summary
- Extend the allowed values for the region parameter to the current 9 AWS Cloud One regions.
- Change the API endpoint to the Cloud One instead of the legacy Conformity one.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
