### PR TITLE
fix: Fix GCP promote quarantine role storage.objects.update permission denied

### DIFF
--- a/post-scan-actions/gcp-python-promote-or-quarantine/main.tf
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/main.tf
@@ -49,8 +49,10 @@ resource "google_project_iam_custom_role" "scanning_bucket_access_role" {
   permissions = var.promote_mode == "move" || var.quarantine_mode == "move" ? [
     "storage.objects.delete",
     "storage.objects.get",
+    "storage.objects.update",
   ] : [
     "storage.objects.get",
+    "storage.objects.update",
   ]
 }
 


### PR DESCRIPTION
# fix: Fix GCP promote quarantine role storage.objects.update permission denied
## Change Summary
Add storage.objects.update role
## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
