### PR TITLE
fix: Fix AWS terraform all in one

### DIFF
--- a/deployment/aws-terraform/README.md
+++ b/deployment/aws-terraform/README.md
@@ -16,7 +16,7 @@ Deploy File Storage Security stacks across different cloud providers with Terraf
     3. `terraform -chdir=all-in-one apply -var="AWSRegion=TheRegionOfDeployment" -var="S3BucketToScan=ProtectingBucketName" -var="ExternalID=YourExternalID"`
 
 - Clean Up
-    - `terraform -chdir=all-in-one destroy`
+    - `terraform -chdir=all-in-one destroy -var="AWSRegion=TheRegionOfDeployment"`
 
 ## Deploy Scanner Stack
 
@@ -26,7 +26,7 @@ Deploy File Storage Security stacks across different cloud providers with Terraf
     3. `terraform -chdir=scanner-stack apply -var="AWSRegion=TheRegionOfDeployment" -var="ExternalID=YourExternalID"`
 
 - Clean Up
-    - `terraform -chdir=scanner-stack destroy`
+    - `terraform -chdir=scanner-stack destroy -var="AWSRegion=TheRegionOfDeployment"`
 
 ## Deploy Storage Stack
 
@@ -37,4 +37,4 @@ Deploy File Storage Security stacks across different cloud providers with Terraf
     3. `terraform -chdir=storage-stack apply -var="AWSRegion=TheRegionOfDeployment" -var="S3BucketToScan=ProtectingBucketName" -var="ExternalID=YourExternalID" -var="ScannerAWSAccount=YourScannerAWSAccount" -var="ScannerSQSURL=YourScannerSQSURL"`
 
 - Clean Up
-    - `terraform -chdir=storage-stack destroy`
+    - `terraform -chdir=storage-stack destroy -var="AWSRegion=TheRegionOfDeployment"`

--- a/deployment/aws-terraform/all-in-one/providers.tf
+++ b/deployment/aws-terraform/all-in-one/providers.tf
@@ -10,6 +10,5 @@ terraform {
 }
 
 provider "aws" {
-  profile = "default"
   region  = var.AWSRegion
 }

--- a/deployment/aws-terraform/all-in-one/variables.tf
+++ b/deployment/aws-terraform/all-in-one/variables.tf
@@ -47,7 +47,7 @@ variable "FSSBucketName" {
 variable "FSSKeyPrefix" {
   type = string
   default = "latest/"
-  dedescription = "File Storage Security key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
+  description = "File Storage Security key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
 }
 
 variable "IAMPolicyPrefix" {


### PR DESCRIPTION
# fix: Fix AWS terraform all in one

## Change Summary
I got few errors when using terraform all in one for AWS, so this PR:
- Fix typo in vars description
- Remove obsolete field in aws provider (make it fails with latest version)
- Fix docs for cleanup (missing region)

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
