### PR TITLE
Fixed multiple full scan AWS buckets scanning deployment name conflict

### DIFF
--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.json
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.json
@@ -510,11 +510,24 @@
        {
         "Ref": "AWS::AccountId"
        },
-       ":stateMachine:ScannerLoopStateMachine\",\n                      \"Input\": {\n                        \"stateBucket.$\": \"$.stateBucket\",\n                        \"stateKey.$\": \"$.stateKey\",\n                        \"limit.$\": \"$.limit\",\n                        \"bucket.$\": \"$.bucket\",\n                        \"AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$\": \"$$.Execution.Id\"\n                      }\n                    },\n                    \"End\": true\n                  },\n                  \"Pass\": {\n                    \"Type\": \"Pass\",\n                    \"End\": true,\n                    \"Result\": {}\n                  }\n                }\n              }\n            ],\n            \"End\": true\n          }\n        }\n      }\n      "
+       ":stateMachine:ScannerLoopStateMachine-",
+       {
+        "Ref": "BucketName"
+       },"\",\n                      \"Input\": {\n                        \"stateBucket.$\": \"$.stateBucket\",\n                        \"stateKey.$\": \"$.stateKey\",\n                        \"limit.$\": \"$.limit\",\n                        \"bucket.$\": \"$.bucket\",\n                        \"AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$\": \"$$.Execution.Id\"\n                      }\n                    },\n                    \"End\": true\n                  },\n                  \"Pass\": {\n                    \"Type\": \"Pass\",\n                    \"End\": true,\n                    \"Result\": {}\n                  }\n                }\n              }\n            ],\n            \"End\": true\n          }\n        }\n      }\n      "
       ]
      ]
     },
-    "StateMachineName": "ScannerLoopStateMachine"
+    "StateMachineName": {
+        "Fn::Join": [
+            "",
+            [
+            "ScannerLoopStateMachine-",
+            {
+            "Ref": "BucketName"
+            }
+            ]
+        ]
+        }
    }
   },
   "FullScanStarterExecutionRole": {
@@ -616,7 +629,17 @@
       ]
      ]
     },
-    "StateMachineName": "fullScanStarterStateMachine"
+    "StateMachineName": {
+        "Fn::Join": [
+         "",
+         [
+          "fullScanStarterStateMachine-",
+          {
+           "Ref": "BucketName"
+          }
+         ]
+        ]
+       }
    },
    "DependsOn": [
     "FullScanStarterExecutionRoleDefaultPolicy",
@@ -714,7 +737,10 @@
       {
        "Ref": "AWS::AccountId"
       },
-      ":stateMachine:fullScanStarterStateMachine"
+      ":stateMachine:fullScanStarterStateMachine-",
+      {
+       "Ref": "BucketName"
+      }
      ]
     ]
    }

--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
@@ -309,9 +309,9 @@ Resources:
               const scanLimitPerIteration = event.limit;
               const bucket = event.bucket;
               const allKeys = await fetchKeys(stateBucket, stateKey);
-              
+
               const filtered = filterKeys(allKeys, scanLimitPerIteration);
-              
+
               // Rewrite file in bucket with remaining keys
               if (filtered.remainingKeys){
                   await writeToBucket(filtered.remainingKeys, stateKey, stateBucket);
@@ -325,7 +325,7 @@ Resources:
                   stateBucket: event.stateBucket,
                   stateKey: event.stateKey
               };
-              
+
               return response;
           };
       Role:
@@ -568,7 +568,7 @@ Resources:
         Fn::Join:
           - ""
           - - |-2
-              
+
                     {
                       "Comment": "A machine that loops trough all files a bucket to scan them with File Storage Security.",
                       "StartAt": "Filter first 1000 keys to scan",
@@ -674,7 +674,9 @@ Resources:
             - Ref: AWS::Region
             - ":"
             - Ref: AWS::AccountId
-            - ":stateMachine:ScannerLoopStateMachine\",
+            - ":stateMachine:ScannerLoopStateMachine-"
+            - Ref: BucketName
+            - "\",
 
               \                      \"Input\": {
 
@@ -721,7 +723,11 @@ Resources:
               \      }
 
               \      "
-      StateMachineName: ScannerLoopStateMachine
+      StateMachineName:
+        Fn::Join:
+          - ""
+          - - ScannerLoopStateMachine-
+            - Ref: BucketName
   FullScanStarterExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -769,7 +775,7 @@ Resources:
         Fn::Join:
           - ""
           - - |-2
-              
+
                     {
                       "Comment": "Kicks of a Full Scan using File Storage Security.",
                       "StartAt": "List all keys in bucket",
@@ -841,7 +847,11 @@ Resources:
               \      }
 
               \      "
-      StateMachineName: fullScanStarterStateMachine
+      StateMachineName:
+        Fn::Join:
+          - ""
+          - - fullScanStarterStateMachine-
+            - Ref: BucketName
     DependsOn:
       - FullScanStarterExecutionRoleDefaultPolicy
       - FullScanStarterExecutionRole
@@ -898,5 +908,5 @@ Outputs:
           - Ref: AWS::Region
           - ":"
           - Ref: AWS::AccountId
-          - :stateMachine:fullScanStarterStateMachine
-
+          - :stateMachine:fullScanStarterStateMachine-
+          - Ref: BucketName


### PR DESCRIPTION
# TITLE

## Change Summary

## PR Checklist

- [ X] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [ X] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ X] Not required

## Other Notes

This is resolution against the bug https://github.com/trendmicro/cloudone-filestorage-plugins/issues/121