### PR TITLE
fix: Remove redundant commas in template.yaml

### DIFF
--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
@@ -1,14 +1,14 @@
 Metadata:
   AWS::ServerlessRepo::Application:
     Name: cloudone-filestorage-plugin-trigger-full-scheduled-scan
-    Description: It deploys all the required resources to trigger a full scan, scheduled or not, on a S3 bucket leveraging an existing Trend File Storage Security deployment.,
-    Author: Trend Cloud One File Storage Security,
-    SpdxLicenseId: Apache-2.0,
-    LicenseUrl: ../../LICENSE,
-    ReadmeUrl: README.md,
+    Description: It deploys all the required resources to trigger a full scan, scheduled or not, on a S3 bucket leveraging an existing Trend File Storage Security deployment.
+    Author: Trend Cloud One File Storage Security
+    SpdxLicenseId: Apache-2.0
+    LicenseUrl: ../../LICENSE
+    ReadmeUrl: README.md
     Labels: ['trendmicro','cloudone','filestorage','s3','bucket','plugin','full','full-scan','scheduled','scheduled-scan']
-    HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins,
-    SemanticVersion: 2.0.0,
+    HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
+    SemanticVersion: 2.0.0
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/scan-triggers/aws-python-bucket-full-and-scheduled-scan
 Parameters:
   BucketName:


### PR DESCRIPTION
# Remove redundant commas in template.yaml

## Change Summary

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
