### PR TITLE
fix: Fix readme of full scheduled scan plugin

### DIFF
--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/README.md
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/README.md
@@ -23,7 +23,7 @@ It deploys all the required resources to trigger a full scan, scheduled or not, 
 
 ### From CloudFormation
 
-1. Download cloudone-filestorage-plugin-full-scan.json
+1. Download [template.yaml](https://raw.githubusercontent.com/trendmicro/cloudone-filestorage-plugins/master/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml)
 2. Visit [CloudFormation's Create stack page](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/template)
 3. Select `Upload a template file` and pick the downloaded template
 4. Fill in the parameters.


### PR DESCRIPTION
# fix: Fix readme of full scheduled scan plugin

## Change Summary

Fix the template file name and add a link to the raw file.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
