### PR TITLE
fix: The FSS tags and metadata of scan failure file will change after performing plugin azure-python-promote-or-quarantine

### DIFF
--- a/post-scan-actions/azure-python-promote-or-quarantine/promoteOrQuarantineFunction/ScanResultHandler/handler.py
+++ b/post-scan-actions/azure-python-promote-or-quarantine/promoteOrQuarantineFunction/ScanResultHandler/handler.py
@@ -45,9 +45,14 @@ def main(message: func.ServiceBusMessage):
     # Log the Service Bus Message as plaintext
 
     message_body = message.get_body().decode("utf-8")
+    message = json.loads(message_body)
 
     logging.info('Python ServiceBus topic trigger processed message.')
     logging.info(f'Message Body: {message_body}')
+
+    if message['scanner_status'] != 0:
+        print('Skip: ', message['scanner_status_message'])
+        return
 
     quarantine_storage_connection_string = os.environ.get('QUARANTINE_STORAGE_CONNECTION_STRING')
     promote_storage_connection_string = os.environ.get('PROMOTE_STORAGE_CONNECTION_STRING')
@@ -55,7 +60,6 @@ def main(message: func.ServiceBusMessage):
     promote_mode = get_promote_mode()
     quarantine_mode = get_quarantine_mode()
 
-    message = json.loads(message_body)
     file_url = message['file_url']
     (_, blob_container, blob_name) = parse_blob_information(file_url)
 


### PR DESCRIPTION
# fix: The FSS tags and metadata of scan failure file will change after performing plugin azure-python-promote-or-quarantine

## Change Summary
1. Fix the plugin azure-python-promote-or-quarantine which will misjudge the event about scan failure.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required
