### PR TITLE
fix: Resolve GitHub Actions restriction in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Get changed files
         id: changed_files
-        uses: tj-actions/changed-files@v35.9.2
+        uses: tj-actions/changed-files@v36
         with:
           json: true
           files: |
@@ -63,6 +63,7 @@ jobs:
     needs:
       - extract-changed-azure-plugins
       - declare-variables
+    if: ${{ needs.extract-changed-azure-plugins.outputs.changed_plugins != '[]' }}
     strategy:
       matrix:
         plugin: ${{ fromJSON(needs.extract-changed-azure-plugins.outputs.changed_plugins) }}


### PR DESCRIPTION
# Fix: Resolve Github Action restriction in workflow

## Change Summary

I encountered an error ([Bad request](https://github.com/trendmicro/cloudone-filestorage-plugins/actions/runs/5139877791)) in a previous PR that was merged. Upon investigation, I discovered that the error was caused by a restriction on using external actions in the "trendmicro/cloudone-filestorage-plugins" repository.

To address this issue, I reviewed other actions within the Trend Micro organization and found examples that were not restricted, such as [scottbrenner/cfn-lint-action@v2](https://github.com/trendmicro/cloudone-community/blob/6a222480dd33739b4450017c953731b673ee2e28/.github/workflows/linter.yml#LL25C15-L25C46). Based on this information, I updated the action version from `v35.9.2` to `v36` to comply with the error message requirement: `svenstaro/upload-release-action@v*, tj-actions/changed-files@v*`.

Additionally, I noticed an error occurring when the changed plugin was empty. To resolve this issue, I added an `if` condition to handle this scenario appropriately.

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
