### PR TITLE
fix: Remove useless code block in aws-python-bucket-full-and-scheduled-scan plugin

### DIFF
--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
@@ -432,13 +432,6 @@ Resources:
           s3_client_path = boto3.client('s3', region, config=Config(s3={'addressing_style': 'path'}, signature_version='s3v4'))
           s3_client_virtual = boto3.client('s3', region, config=Config(s3={'addressing_style': 'virtual'}, signature_version='s3v4'))
 
-          try:
-              with open('version.json') as version_file:
-                  version = json.load(version_file)
-                  print(f'version: {version}')
-          except Exception as ex:
-              print('failed to get version: ' + str(ex))
-
           def create_presigned_url(bucket_name, object_name, expiration):
               """Generate a presigned URL to share an S3 object
 


### PR DESCRIPTION
# Fix: Remove useless code block in aws-python-bucket-full-and-scheduled-scan plugin

## Change Summary

- There is no `version.json` in the Lambda function in this plugin. So delete code block handling it.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
