### PR TITLE
Change the type of TrendMicroManagementAccount to string

### DIFF
--- a/deployment/aws-terraform/account-scanner-stack/variables.tf
+++ b/deployment/aws-terraform/account-scanner-stack/variables.tf
@@ -72,7 +72,7 @@ variable "FSSKeyPrefix" {
 
 variable "TrendMicroManagementAccount" {
   type = string
-  default = 415485722356
+  default = "415485722356"
   description = "This account will be given permission to modify the stacks for upgrades and troubleshooting purposes."
 }
 

--- a/deployment/aws-terraform/all-in-one/variables.tf
+++ b/deployment/aws-terraform/all-in-one/variables.tf
@@ -171,8 +171,8 @@ variable "SubnetIDs" {
 }
 
 variable "TrendMicroManagementAccount" {
-  type = number
-  default = 415485722356
+  type = string
+  default = "415485722356"
   description = "This account will be given permission to modify the stacks for upgrades and troubleshooting purposes."
 }
 

--- a/deployment/aws-terraform/scanner-stack/variables.tf
+++ b/deployment/aws-terraform/scanner-stack/variables.tf
@@ -125,7 +125,7 @@ variable "SubnetIDs" {
 }
 
 variable "TrendMicroManagementAccount" {
-  type = number
-  default = 415485722356
+  type = string
+  default = "415485722356"
   description = "This account will be given permission to modify the stacks for upgrades and troubleshooting purposes."
 }

--- a/deployment/aws-terraform/storage-stack/variables.tf
+++ b/deployment/aws-terraform/storage-stack/variables.tf
@@ -171,8 +171,8 @@ variable "SubnetIDs" {
 }
 
 variable "TrendMicroManagementAccount" {
-  type = number
-  default = 415485722356
+  type = string
+  default = "415485722356"
   description = "This account will be given permission to modify the stacks for upgrades and troubleshooting purposes."
 }
 


### PR DESCRIPTION
# Change the type of TrendMicroManagementAccount to string

## Change Summary

- The TrendMicroManagementAccount should be string type. Since the account ID has the possibility of beginning with 0.
- Change to type of variable `TrendMicroManagementAccount` in every variables.tf.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] Not required

## Other Notes
