### PR TITLE
chore: Update Azure artifact version and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
   - [ ] Not required
 - Plugins that have versioning
   - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
+  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
   - [ ] Not required
 
 ## Other Notes

--- a/post-scan-actions/azure-python-promote-or-quarantine/template.json
+++ b/post-scan-actions/azure-python-promote-or-quarantine/template.json
@@ -11,7 +11,7 @@
         },
         "functionsPackageLocation": {
             "type": "string",
-            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-promote-or-quarantine-1.0.0",
+            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-promote-or-quarantine-1.2.0",
             "metadata": {
                 "description": "Warning: Do not modify the field. Modifications may cause your deployment to fail."
             }


### PR DESCRIPTION
# Chore: Update Azure artifact version and PR template

## Change Summary

1. Update pull request check list.
2. Update the version in Azure promote or quarantine template file.

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [v] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [v] Not required

## Other Notes

New template deploy the promote or quarantine with the code which enhanced on v1.0.2.
![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/110873658/e935a404-02fb-435b-8995-be7bff47fd24)

Success to promote a 2.8GB file
![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/110873658/2ab3b26a-b0d2-4ee2-8a98-9d143d904537)


