### PR TITLE
feat: Migrate classic Application Insights to workspace-based Application Insights for Azure plugins

### DIFF
--- a/post-scan-actions/azure-python-promote-or-quarantine/README.md
+++ b/post-scan-actions/azure-python-promote-or-quarantine/README.md
@@ -114,15 +114,21 @@ If you want to deploy Promote or Quarantine Plugin in Azure VNet, ensure that yo
         VNETFilePrivateDNSZoneResourceID="$FILE_PRIVATE_DNS_ZONE_RESOURCE_ID" \
         VNETBlobPrivateDNSZoneResourceID="$BLOB_PRIVATE_DNS_ZONE_RESOURCE_ID" \
         VNETRestrictedAccessForApplicationInsights=true|false \
+        VNETRestrictedAccessForAzureMonitorResources=true|false \
     ```
 
-    Set the `VNETRestrictedAccessForApplicationInsights` parameter to `true` if you want to log via the private network. Otherwise, leave it as `false`.
+    Set the `VNETRestrictedAccessForApplicationInsights` and `VNETRestrictedAccessForAzureMonitorResources` parameters to `true` if you want to log via the private network. Otherwise, leave them as `false`.
 
-1. If you are using Azure Monitor Private Link Scopes(AMPLS) with VNet, which means you have set the `VNETRestrictedAccessForApplicationInsights` parameter to `true` in the previous step, you should add the application insight to AMPLS using the following command. The APPLICATION_INSIGHT_RESOURCE_ID can be found in the deployment output `applicationInsightResourceID`.
+1. If you are using Azure Monitor Private Link Scopes(AMPLS) with VNet, which means you have set the `VNETRestrictedAccessForApplicationInsights` and `VNETRestrictedAccessForAzureMonitorResources` parameters to `true` in the previous step, you should add the application insight and the Log Analytics workspace to AMPLS using the following command. The APPLICATION_INSIGHT_RESOURCE_ID and LOG_ANALYTICS_WORKSPACE_RESOURCE_ID can be found in the deployment output `applicationInsightResourceID` and `logAnalyticsWorkspaceResourceID`.
 
     ```bash
     az monitor private-link-scope scoped-resource create \
         --linked-resource $APPLICATION_INSIGHT_RESOURCE_ID \
+        --name $SCOPED_RESOURCE_NAME \
+        --resource-group $AMPLS_RESOURCE_GROUP \
+        --scope-name $AMPLS_NAME
+    az monitor private-link-scope scoped-resource create \
+        --linked-resource $LOG_ANALYTICS_WORKSPACE_RESOURCE_ID \
         --name $SCOPED_RESOURCE_NAME \
         --resource-group $AMPLS_RESOURCE_GROUP \
         --scope-name $AMPLS_NAME

--- a/post-scan-actions/azure-python-promote-or-quarantine/template.json
+++ b/post-scan-actions/azure-python-promote-or-quarantine/template.json
@@ -11,7 +11,7 @@
         },
         "functionsPackageLocation": {
             "type": "string",
-            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-promote-or-quarantine-1.2.0",
+            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-promote-or-quarantine-1.3.0",
             "metadata": {
                 "description": "Warning: Do not modify the field. Modifications may cause your deployment to fail."
             }
@@ -71,6 +71,13 @@
                 "description": "The method by which files were quarantined.<br/>(Options: move, copy)."
             }
         },
+        "LogAnalyticsWorkspaceResourceID": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "This field requires the resource ID of the existing Log Analytics workspace that the deployed Application Insights resources is associated with. If you don't want to manage the Log Analytics workspace by yourself, please leave this field blank."
+            }
+        },
         "VNETResourceID": {
             "defaultValue": "",
             "type": "String",
@@ -110,7 +117,14 @@
             "defaultValue": false,
             "type": "Bool",
             "metadata": {
-                "description": "<b>[VNet Only]</b><br />Indicates whether to restrict public access to Application Insights. If set to true, it means that Application Insights can only be accessed through Azure Monitor Private Link Scope. If you don't add the Application Insight to the Azure Monitor Private Link Scope, you won't be able to ingest or query data. For more information on how to configure Private Link for Application Insights, please see <a href='https://cloudone.trendmicro.com/docs/file-storage-security/azure-vnet-deployment/'>Restrict access to Application Insights'</a>. If VNet is not required, please choose false."
+                "description": "<b>[To Be Deprecated][VNet Only]</b><br />The parameter will be replaced by <b>VNETRestrictedAccessForAzureMonitorResources</b> after 2024/10/31. Before it's fully deprecated, configuring either one to true means to restrict public network access to Application Insights and Azure Monitor resources.<br />Indicates whether to restrict public access to Application Insights. If set to true, Application Insights can only be accessed through Azure Monitor Private Link Scope. If you don't add the Application Insight to the Azure Monitor Private Link Scope, you won't be able to ingest or query data. For more information on how to configure Private Link for Application Insights, see <a href='https://cloudone.trendmicro.com/docs/file-storage-security/azure-vnet-deployment/'>Restrict access to Application Insights'</a>. If VNet is not required, choose false."
+            }
+        },
+        "VNETRestrictedAccessForAzureMonitorResources": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "<b>[VNet Only]</b><br />Indicates if public access to Azure Monitor resources is restricted, for example, Application Insights or Log Analytics workspace. If set to true, Azure Monitor resources can only be accessed through the Azure Monitor Private Link Scope. If you don't add the Application Insights and Log Analytics workspace to the Azure Monitor Private Link Scope, you won't be able to ingest or query data. For more information on how to configure Private Link for Application Insights and Log Analytics workspace, see <a href='https://cloudone.trendmicro.com/docs/file-storage-security/azure-vnet-deployment/'>Restrict access to Application Insights and Log Analytics workspace'</a>. If VNet is not required, choose false."
             }
         }
     },
@@ -170,7 +184,8 @@
         "publicNetworkAccess": "[if(variables('withVNet'), 'Disabled', 'Enabled')]",
         "filePrivateZoneGroupName": "filePrivateDnsZoneGroup",
         "blobPrivateZoneGroupName": "blobPrivateDnsZoneGroup",
-        "appInsightPublicAccess": "[if(parameters('VNETRestrictedAccessForApplicationInsights'), 'Disabled', 'Enabled')]"
+        "azureMonitorResourcesPublicAccess": "[if(and(variables('withVNet'), or(parameters('VNETRestrictedAccessForApplicationInsights'), parameters('VNETRestrictedAccessForAzureMonitorResources'))), 'Disabled', 'Enabled')]",
+        "pluginLogAnalyticsWorkspaceName": "[concat('tmlaws0', toLower(uniquestring(resourceGroup().id)))]"
     },
     "resources": [
         {
@@ -403,6 +418,24 @@
             }
         },
         {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[variables('pluginLogAnalyticsWorkspaceName')]",
+            "condition": "[not(empty(parameters('LogAnalyticsWorkspaceResourceID')))]",
+            "location": "[variables('location')]",
+            "properties": {
+                "sku": {
+                    "name": "pergb2018"
+                },
+                "retentionInDays": 90,
+                "features": {
+                    "enableLogAccessUsingOnlyResourcePermissions": true
+                },
+                "publicNetworkAccessForIngestion": "[variables('azureMonitorResourcesPublicAccess')]",
+                "publicNetworkAccessForQuery": "[variables('azureMonitorResourcesPublicAccess')]"
+            }
+        },
+        {
             "type": "microsoft.insights/components",
             "apiVersion": "2020-02-02",
             "name": "[variables('applicationInsightsName')]",
@@ -413,8 +446,11 @@
             },
             "properties": {
                 "Application_Type": "web",
-                "publicNetworkAccessForIngestion": "[variables('appInsightPublicAccess')]",
-                "publicNetworkAccessForQuery": "[variables('appInsightPublicAccess')]"
+                "Flow_Type": "Bluefield",
+                "Request_Source": "rest",
+                "WorkspaceResourceId": "[if(empty(parameters('LogAnalyticsWorkspaceResourceID')), resourceId('Microsoft.OperationalInsights/workspaces/', variables('pluginLogAnalyticsWorkspaceName')), parameters('LogAnalyticsWorkspaceResourceID'))]",
+                "publicNetworkAccessForIngestion": "[variables('azureMonitorResourcesPublicAccess')]",
+                "publicNetworkAccessForQuery": "[variables('azureMonitorResourcesPublicAccess')]"
             }
         },
         {
@@ -542,6 +578,10 @@
         "applicationInsightResourceID": {
             "type": "string",
             "value": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
+        },
+        "logAnalyticsWorkspaceResourceID": {
+            "type": "string",
+            "value": "[if(empty(parameters('LogAnalyticsWorkspaceResourceID')), resourceId('Microsoft.OperationalInsights/workspaces/', variables('pluginLogAnalyticsWorkspaceName')), parameters('LogAnalyticsWorkspaceResourceID'))]"
         }
     }
 }

--- a/post-scan-actions/azure-python-slack-notification/template.json
+++ b/post-scan-actions/azure-python-slack-notification/template.json
@@ -11,7 +11,7 @@
         },
         "functionsPackageLocation": {
             "type": "string",
-            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-slack-notification-1.0.0",
+            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-slack-notification-1.1.0",
             "metadata": {
                 "description": "Warning: Do not modify the field. Modifications may cause your deployment to fail."
             }
@@ -40,6 +40,13 @@
             "metadata": {
                 "description": "The resource ID of the scan result topic Server Bus topic in storage stack."
             }
+        },
+        "LogAnalyticsWorkspaceResourceID": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "This field requires the resource ID of the existing Log Analytics workspace that the deployed Application Insights resources is associated with. If you don't want to manage the Log Analytics workspace by yourself, please leave this field blank."
+            }
         }
     },
     "variables": {
@@ -61,7 +68,8 @@
         "scanResultTopicSubscriptionName": "fss-slack-subscription",
         "scanResultTopicAPIVersion": "2017-04-01",
         "functionAppAPIVersion": "2020-12-01",
-        "scanResultSubscriptionDeployment": "scanResultSubscription"
+        "scanResultSubscriptionDeployment": "scanResultSubscription",
+        "pluginLogAnalyticsWorkspaceName": "[concat('tmlaws0', toLower(uniquestring(resourceGroup().id)))]"
     },
     "resources": [{
             "type": "Microsoft.Storage/storageAccounts",
@@ -177,6 +185,22 @@
             }
         },
         {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[variables('pluginLogAnalyticsWorkspaceName')]",
+            "condition": "[not(empty(parameters('LogAnalyticsWorkspaceResourceID')))]",
+            "location": "[variables('location')]",
+            "properties": {
+                "sku": {
+                    "name": "pergb2018"
+                },
+                "retentionInDays": 90,
+                "features": {
+                    "enableLogAccessUsingOnlyResourcePermissions": true
+                }
+            }
+        },
+        {
             "type": "microsoft.insights/components",
             "apiVersion": "2020-02-02-preview",
             "name": "[variables('applicationInsightsName')]",
@@ -187,7 +211,10 @@
             },
             "properties": {
                 "Application_Type": "web",
-                "ApplicationId": "[variables('applicationInsightsName')]"
+                "ApplicationId": "[variables('applicationInsightsName')]",
+                "Flow_Type": "Bluefield",
+                "Request_Source": "rest",
+                "WorkspaceResourceId": "[if(empty(parameters('LogAnalyticsWorkspaceResourceID')), resourceId('Microsoft.OperationalInsights/workspaces/', variables('pluginLogAnalyticsWorkspaceName')), parameters('LogAnalyticsWorkspaceResourceID'))]"
             }
         },
         {

--- a/post-scan-actions/azure-python-teams-notification/template.json
+++ b/post-scan-actions/azure-python-teams-notification/template.json
@@ -11,7 +11,7 @@
         },
         "functionsPackageLocation": {
             "type": "string",
-            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-teams-notification-1.0.0",
+            "defaultValue": "https://github.com/trendmicro/cloudone-filestorage-plugins/releases/download/azure-python-teams-notification-1.1.0",
             "metadata": {
                 "description": "Warning: Do not modify the field. Modifications may cause your deployment to fail."
             }
@@ -34,6 +34,13 @@
             "metadata": {
                 "description": "The resource ID of the scan result topic Server Bus topic in storage stack."
             }
+        },
+        "LogAnalyticsWorkspaceResourceID": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "This field requires the resource ID of the existing Log Analytics workspace that the deployed Application Insights resources is associated with. If you don't want to manage the Log Analytics workspace by yourself, please leave this field blank."
+            }
         }
     },
     "variables": {
@@ -55,7 +62,8 @@
         "scanResultTopicSubscriptionName": "fss-teams-subscription",
         "scanResultTopicAPIVersion": "2017-04-01",
         "functionAppAPIVersion": "2020-12-01",
-        "scanResultSubscriptionDeployment": "scanResultSubscription"
+        "scanResultSubscriptionDeployment": "scanResultSubscription",
+        "pluginLogAnalyticsWorkspaceName": "[concat('tmlaws0', toLower(uniquestring(resourceGroup().id)))]"
     },
     "resources": [{
             "type": "Microsoft.Storage/storageAccounts",
@@ -167,6 +175,22 @@
             }
         },
         {
+            "type": "Microsoft.OperationalInsights/workspaces",
+            "apiVersion": "2021-12-01-preview",
+            "name": "[variables('pluginLogAnalyticsWorkspaceName')]",
+            "condition": "[not(empty(parameters('LogAnalyticsWorkspaceResourceID')))]",
+            "location": "[variables('location')]",
+            "properties": {
+                "sku": {
+                    "name": "pergb2018"
+                },
+                "retentionInDays": 90,
+                "features": {
+                    "enableLogAccessUsingOnlyResourcePermissions": true
+                }
+            }
+        },
+        {
             "type": "microsoft.insights/components",
             "apiVersion": "2020-02-02-preview",
             "name": "[variables('applicationInsightsName')]",
@@ -177,7 +201,10 @@
             },
             "properties": {
                 "Application_Type": "web",
-                "ApplicationId": "[variables('applicationInsightsName')]"
+                "ApplicationId": "[variables('applicationInsightsName')]",
+                "Flow_Type": "Bluefield",
+                "Request_Source": "rest",
+                "WorkspaceResourceId": "[if(empty(parameters('LogAnalyticsWorkspaceResourceID')), resourceId('Microsoft.OperationalInsights/workspaces/', variables('pluginLogAnalyticsWorkspaceName')), parameters('LogAnalyticsWorkspaceResourceID'))]"
             }
         },
         {


### PR DESCRIPTION
# Feat: Migrate classic Application Insights to workspace-based Application Insights for Azure plugins

## Change Summary

Azure announced that [they will retire classic Application Insights on 29 February 2024](https://azure.microsoft.com/en-us/updates/we-re-retiring-classic-application-insights-on-29-february-2024/).

- Add a new parameter, `LogAnalyticsWorkspaceResourceID`, to support it.
- Add a new parameter, `VNETRestrictedAccessForAzureMonitorResources`, in `azure-python-promote-or-quarantine` plugin.
  - Log Analytics workspaces also provide properties, `publicNetworkAccessForIngestion` and `publicNetworkAccessForQuery`, to configure the network access. We think the Azure Monitor resources, like Application Insights and Log Analytics workspaces, should allow or disallow public network access at the same time.
  - When any of `VNETRestrictedAccessForApplicationInsights` and `VNETRestrictedAccessForAzureMonitorResources` is `true`, we disable public network access of all Application Insights and Log Analytics workspace resources.
  - We only allow public network access to those resources when both of the parameters are set to `false`.

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [x] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [x] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
