### PR TITLE
fix: AWS quarantine plugin template

### DIFF
--- a/post-scan-actions/aws-python-promote-or-quarantine/template.yml
+++ b/post-scan-actions/aws-python-promote-or-quarantine/template.yml
@@ -13,7 +13,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: [trendmicro, cloudone, filestorage, s3, bucket, plugin, promote, quarantine]
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 1.3.0
+    SemanticVersion: 1.3.1
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-promote-or-quarantine
 
 Parameters:
@@ -99,7 +99,7 @@ Conditions:
   PutACL:
     !Not [!Equals [!Ref ACL, '']]
   IsBucketSSEKMSEnabled:
-    !Not [!Equals [!Ref KMSKeyARNs, '']]
+    !Not [!Equals [!Join ["", !Ref KMSKeyARNs], '']]
   HasPermissionsBoundary:
     !Not [!Equals [!Ref PermissionsBoundary, '']]
   VpcEnabled: !Not [!Or [!Equals [!Ref VpcSubnetId, ''], !Equals [!Ref VpcSecurityGroupId, '']]]


### PR DESCRIPTION
# fix: AWS quarantine plugin template

## Change Summary

Fix AWS quarantine plugin template publish error, because SAM's "Fn::Equals" does not support comparing comma delimited parameter.

```
➜  aws-python-promote-or-quarantine git:(master) ✗ sam validate -t packaged.yaml --lint
E8003 Every Fn::Equals object requires a list of 2 string parameters
/Users/jack_c_tang/dev/fss-public/cloudone-filestorage-plugins/post-scan-actions/aws-python-promote-or-quarantine/packaged.yaml:140:9

Error: Linting failed. At least one linting rule was matched to the provided template.
```

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [x] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
