### PR TITLE
fix: deploy stack failed because of the kmskey parameter

### DIFF
--- a/post-scan-actions/aws-python-promote-or-quarantine/template.yml
+++ b/post-scan-actions/aws-python-promote-or-quarantine/template.yml
@@ -13,7 +13,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: [trendmicro, cloudone, filestorage, s3, bucket, plugin, promote, quarantine]
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 1.3.1
+    SemanticVersion: 1.3.2
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-promote-or-quarantine
 
 Parameters:
@@ -159,7 +159,7 @@ Resources:
                     - QuarantineEnabled
                     - !Sub arn:${AWS::Partition}:s3:::${QuarantineBucketName}/*
                     - !Ref AWS::NoValue
-              - !If 
+              - !If
                 - IsBucketSSEKMSEnabled
                 - Effect: Allow
                   Action:
@@ -191,7 +191,6 @@ Resources:
           PROMOTEMODE: !Ref PromoteMode
           QUARANTINEBUCKET: !Ref QuarantineBucketName
           QUARANTINEMODE: !Ref QuarantineMode
-          KMSKEYARN: !Ref KMSKeyARNs
           ACL: !Ref ACL
       Events:
         ScanResult:


### PR DESCRIPTION
# Deploy stack failed because of the KMSKeyARNs parameter

## Change Summary
Remove KMSKeyARNs from Lambda function's env var since it's not necessary. 

Test result:
![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/84834340/6fa3e3d6-2ae9-4510-8d6c-dbaea7415dc2)
![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/84834340/f01fdebe-0be7-4709-b20e-fb8ce515e715)


## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [x] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
