### PR TITLE
fix: make aws promote quarantine template support multiple subnets

### DIFF
--- a/post-scan-actions/aws-python-promote-or-quarantine/template.yml
+++ b/post-scan-actions/aws-python-promote-or-quarantine/template.yml
@@ -54,17 +54,17 @@ Parameters:
       The method by which files were quarantined.
       (Options: move, copy)
   VpcSubnetId:
-    Type: String
+    Type: CommaDelimitedList 
     Default: ''
     Description: |
-      [Optional] The subnet ID of the VPC where the S3 bucket is located.
-      Leave it blank to disable using a VPC.
+      [Optional] A comma-separated list of VPC Subnet IDs that are attached to Lambda functions.
+      Leave it blank if you don't want to attach Lambda functions to a VPC.
   VpcSecurityGroupId:
-    Type: String
+    Type: CommaDelimitedList 
     Default: ''
     Description: |
-      [Optional] The security group ID of the VPC where the S3 bucket is located.
-      Leave it blank to disable using a VPC.
+      [Optional] A comma-separated list of the VPC Security Group IDs that are attached to Lambda functions. 
+      Leave it blank if you don't want to attach Lambda functions to a VPC.
   KMSKeyARNs:
     Type: CommaDelimitedList
     Default: ''
@@ -103,7 +103,12 @@ Conditions:
   HasPermissionsBoundary:
     !Not [!Equals [!Ref PermissionsBoundary, '']]
   VpcEnabled: !Not [!Or [!Equals [!Ref VpcSubnetId, ''], !Equals [!Ref VpcSecurityGroupId, '']]]
-
+    !Not [
+      !Or [
+        !Equals [!Join [',', !Ref VpcSubnetId], ''],
+        !Equals [!Join [',', !Ref VpcSecurityGroupId], ''],
+      ],
+    ]
 Resources:
   PromoteOrQuarantineLambdaExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
# [fix: make aws promote quarantine template support multiple subnets](https://trendmicro.atlassian.net/browse/C1FSS-193)

## Change Summary

Purpose:

Align the VPC config with the stack template to support connecting multiple subnets with the promote quarantine plugin.

Verify the solution:

### Deploy the promote /quarantine plugin with two subnet IDs and two security group ids.

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/e386aff1-ab20-4541-9451-ca07b5203c00)

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/043a854e-b338-48a9-8753-08a268207ce6)

<img width="1148" alt="image" src="https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/48b5952e-8f1d-4e5b-8a03-38a92bd26d13">

### Deploy the promote /quarantine plugin with one subnet ID and one security group ID.

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/38330ee1-d6bd-4ae5-950b-fd775b8a05c3)

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/51001d98-b79f-4880-ad7c-3eff2349657e)

<img width="1181" alt="image" src="https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/7d016044-266a-48ed-bdee-4d58cd053902">

### Deploy the promote /quarantine plugin with only one subnet ID, and it should not be enabled the VPC

<img width="1181" alt="image" src="https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/57b9c44e-e547-457b-b5d0-987d98d5b035">

### Deploy the promote /quarantine plugin with only one security group ID, and it should not be enabled the VPC

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/2cc448b1-3479-42f7-b315-57d6a24a934a)

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/798cf378-09b9-4267-ab87-7c334f7aa80e)

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/07a37816-0c27-46a4-81ea-efb2e91fde4b)

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [x] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
