### PR TITLE
Update the syntax error of aws python promote or quarantine

### DIFF
--- a/post-scan-actions/aws-python-promote-or-quarantine/template.yml
+++ b/post-scan-actions/aws-python-promote-or-quarantine/template.yml
@@ -11,9 +11,19 @@ Metadata:
     SpdxLicenseId: Apache-2.0
     LicenseUrl: ../../LICENSE
     ReadmeUrl: README.md
-    Labels: [trendmicro, cloudone, filestorage, s3, bucket, plugin, promote, quarantine]
+    Labels:
+      [
+        trendmicro,
+        cloudone,
+        filestorage,
+        s3,
+        bucket,
+        plugin,
+        promote,
+        quarantine,
+      ]
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 1.3.3
+    SemanticVersion: 1.3.4
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-promote-or-quarantine
 
 Parameters:
@@ -54,16 +64,16 @@ Parameters:
       The method by which files were quarantined.
       (Options: move, copy)
   VpcSubnetId:
-    Type: CommaDelimitedList 
+    Type: CommaDelimitedList
     Default: ''
     Description: |
       [Optional] A comma-separated list of VPC Subnet IDs that are attached to Lambda functions.
       Leave it blank if you don't want to attach Lambda functions to a VPC.
   VpcSecurityGroupId:
-    Type: CommaDelimitedList 
+    Type: CommaDelimitedList
     Default: ''
     Description: |
-      [Optional] A comma-separated list of the VPC Security Group IDs that are attached to Lambda functions. 
+      [Optional] A comma-separated list of the VPC Security Group IDs that are attached to Lambda functions.
       Leave it blank if you don't want to attach Lambda functions to a VPC.
   KMSKeyARNs:
     Type: CommaDelimitedList
@@ -92,21 +102,16 @@ Parameters:
       [Optional] The ARN of the policy used to set the permissions boundary for all the roles that will be created. Leave it blank to disable using a permissions boundary.
 
 Conditions:
-  PromoteEnabled:
-    !Not [!Equals [!Ref PromoteBucketName, '']]
-  QuarantineEnabled:
-    !Not [!Equals [!Ref QuarantineBucketName, '']]
-  PutACL:
-    !Not [!Equals [!Ref ACL, '']]
-  IsBucketSSEKMSEnabled:
-    !Not [!Equals [!Join ["", !Ref KMSKeyARNs], '']]
-  HasPermissionsBoundary:
-    !Not [!Equals [!Ref PermissionsBoundary, '']]
-  VpcEnabled: !Not [!Or [!Equals [!Ref VpcSubnetId, ''], !Equals [!Ref VpcSecurityGroupId, '']]]
+  PromoteEnabled: !Not [!Equals [!Ref PromoteBucketName, '']]
+  QuarantineEnabled: !Not [!Equals [!Ref QuarantineBucketName, '']]
+  PutACL: !Not [!Equals [!Ref ACL, '']]
+  IsBucketSSEKMSEnabled: !Not [!Equals [!Join ['', !Ref KMSKeyARNs], '']]
+  HasPermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, '']]
+  VpcEnabled:
     !Not [
       !Or [
-        !Equals [!Join [',', !Ref VpcSubnetId], ''],
-        !Equals [!Join [',', !Ref VpcSecurityGroupId], ''],
+        !Equals [!Join ['', !Ref VpcSubnetId], ''],
+        !Equals [!Join ['', !Ref VpcSecurityGroupId], ''],
       ],
     ]
 Resources:
@@ -182,14 +187,11 @@ Resources:
       Timeout: 30
       Tracing: Active
       Role: !GetAtt PromoteOrQuarantineLambdaExecutionRole.Arn
-      VpcConfig:
-        !If
-          - VpcEnabled
-          - SubnetIds:
-              - !Ref VpcSubnetId
-            SecurityGroupIds:
-              - !Ref VpcSecurityGroupId
-          - !Ref AWS::NoValue
+      VpcConfig: !If
+        - VpcEnabled
+        - SubnetIds: !Ref VpcSubnetId
+          SecurityGroupIds: !Ref VpcSecurityGroupId
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           PROMOTEBUCKET: !Ref PromoteBucketName


### PR DESCRIPTION
# Update the syntax error of aws python promote or quarantine

## Change Summary

Purpose:

Fix the syntax error in the template(post-scan-actions/aws-python-promote-or-quarantine/template.yml).

Verify:

The SAM CLI is verified.
<img width="1430" alt="image" src="https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/f116d4e3-26c6-434d-818e-a933c57ff80c">

Deploy to CloudFormation is verified.
<img width="1319" alt="image" src="https://github.com/trendmicro/cloudone-filestorage-plugins/assets/7638055/7edc7124-ae4a-456a-9650-7d3f69d0a59b">

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
