### PR TITLE
fix: GCP promote quarantine failed to add tag in scanning bucket

### DIFF
--- a/post-scan-actions/gcp-python-promote-or-quarantine/main.tf
+++ b/post-scan-actions/gcp-python-promote-or-quarantine/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = "~> 4.0.0"
+      version = "~> 5.11.0"
     }
   }
 }
@@ -49,8 +49,10 @@ resource "google_project_iam_custom_role" "scanning_bucket_access_role" {
   permissions = var.promote_mode == "move" || var.quarantine_mode == "move" ? [
     "storage.objects.delete",
     "storage.objects.get",
+    "storage.objects.update"
   ] : [
     "storage.objects.get",
+    "storage.objects.update"
   ]
 }
 


### PR DESCRIPTION
# Fix GCP promote and quarantine failed to tag file in scanning bucket

## Change Summary

- Update GCP terraform module
- Allow promote and quarantine function to update object in scanning bucket

## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
