### PR TITLE
Update aws-nodejs-securityhub plugin template

### DIFF
--- a/post-scan-actions/aws-nodejs-securityhub-integration/template.yaml
+++ b/post-scan-actions/aws-nodejs-securityhub-integration/template.yaml
@@ -30,6 +30,14 @@ Resources:
             Effect: Allow
             Resource:
               !Sub arn:${AWS::Partition}:securityhub:${AWS::Region}:${AWS::AccountId}:product/${AWS::AccountId}/default
+          - Action: logs:CreateLogGroup
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
+          - Action:
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Effect: Allow
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
         Version: "2012-10-17"
       PolicyName: SentToSecurityHubLambdaFunctionServiceRoleDefaultPolicy
       Roles:


### PR DESCRIPTION
# Update aws-nodejs-securityhub plugin template

## Change Summary

Update lambda role policy to allow lambda write log to CloudWatch.

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
