### PR TITLE
Fix: update aws-sdk and add logging info

### DIFF
--- a/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
+++ b/scan-triggers/aws-python-bucket-full-and-scheduled-scan/template.yaml
@@ -11,7 +11,7 @@ Metadata:
     ReadmeUrl: README.md
     Labels: ['trendmicro','cloudone','filestorage','s3','bucket','plugin','full','full-scan','scheduled','scheduled-scan']
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 2.1.0
+    SemanticVersion: 2.1.1
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/scan-triggers/aws-python-bucket-full-and-scheduled-scan
 Parameters:
   BucketName:
@@ -249,16 +249,25 @@ Resources:
     Properties:
       Code:
         ZipFile: |
-          const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
-          const client = new S3Client();
+          const util = require('util')
+          const { PutObjectCommand, S3 } = require('@aws-sdk/client-s3');
+          const client = new S3({});
 
           const fetchKeys = async (bucket, key) => {
             try {
-              const result = await client.send(new GetObjectCommand({
+              const result = await client.getObject({
                 Bucket: bucket,
                 Key: key
-              }))
-              const keys = JSON.parse(result.Body.toString('utf-8'));
+              })
+
+              if (!result.Body) {
+                throw new Error("Bucket key not found");
+              }
+
+              console.log("[FilterFunction] Finishing getting keys, start parsing...")
+              const bodyStream = result.Body;
+              const keys = JSON.parse(await bodyStream.transformToString());
+
               return keys;
             } catch (error) {
               throw error;
@@ -289,7 +298,7 @@ Resources:
           };
 
           exports.lambda_handler = async (event) => {
-            console.log(event);
+            console.log(`[FilterFunction] event: ${util.inspect(event, {depth: null})}`);
             const stateBucket = event.stateBucket;
             const stateKey = event.stateKey;
             const scanLimitPerIteration = event.limit;


### PR DESCRIPTION
# Update Full Scan Plugin FilterFunction 

[Deprecated] Since it is same with #176 

## Change Summary

> All changes are in FilterFunction lambda

> sdk `S3.getObject` reference: https://github.com/aws/aws-sdk-js-v3/issues/1877#issuecomment-1287546956 

1. update sdk use of `S3Client` to S3
2. update `client.send(new GetObjectCommand...` to `S3.getObject({...`
3. add more log info in Filter function

![image](https://github.com/trendmicro/cloudone-filestorage-plugins/assets/139741914/ea9eec51-d786-456c-8f96-3ef1bb8d6da8)


## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [x] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
