### PR TITLE
chore: Add logging statement to aws-python-promote-or-quarantine handler

### DIFF
--- a/post-scan-actions/aws-python-promote-or-quarantine/handler.py
+++ b/post-scan-actions/aws-python-promote-or-quarantine/handler.py
@@ -132,6 +132,9 @@ def delete_objects(bucket, prefix, objects):
     s3.delete_objects(Bucket=bucket, Delete=objects)
 
 def lambda_handler(event, context):
+
+    print('[Plugin] aws-python-promote-or-quarantin handler invoked')
+
     acl = os.environ.get('ACL')
 
     quarantine_bucket = os.environ.get('QUARANTINEBUCKET')

--- a/post-scan-actions/aws-python-promote-or-quarantine/template.yml
+++ b/post-scan-actions/aws-python-promote-or-quarantine/template.yml
@@ -23,7 +23,7 @@ Metadata:
         quarantine,
       ]
     HomePageUrl: https://github.com/trendmicro/cloudone-filestorage-plugins
-    SemanticVersion: 1.4.0
+    SemanticVersion: 1.4.1
     SourceCodeUrl: https://github.com/trendmicro/cloudone-filestorage-plugins/tree/master/post-scan-actions/aws-python-promote-or-quarantine
 
 Parameters:


### PR DESCRIPTION
# Enhance plugin logging information

## Change Summary

1. this handler has same code with inner post-action-tag function. Add a starter logging information for helping debug

## PR Checklist

- [ ] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [ ] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [ ] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
