### PR TITLE
fix: fix SyntaxWarning for invalid escape character

### DIFF
--- a/post-scan-actions/aws-python-conformity-custom-check/handler.py
+++ b/post-scan-actions/aws-python-conformity-custom-check/handler.py
@@ -53,7 +53,7 @@ def lambda_handler(event, context):
             ccaccountid = get_cc_accountid(account_id)
 
             # Get the bucket & object details
-            s3_domain_pattern = "s3(\..+)?\.amazonaws.com"
+            s3_domain_pattern = r"s3(\..+)?\.amazonaws.com"
             url = urllib.parse.urlparse(message["file_url"])
             # check pre-signed URL type, path or virtual
             if re.fullmatch(s3_domain_pattern, url.netloc):

--- a/post-scan-actions/aws-python-promote-or-quarantine/handler.py
+++ b/post-scan-actions/aws-python-promote-or-quarantine/handler.py
@@ -36,7 +36,7 @@ MODES = {
 }
 
 DEFAULT_MODE = 'move'
-S3_DOMAIN_PATTERN = 's3(\..+)?\.amazonaws.com'
+S3_DOMAIN_PATTERN = r's3(\..+)?\.amazonaws.com'
 FSS_TAG_PREFIX = 'fss-'
 
 CODE_EMPTY = 0


### PR DESCRIPTION
# Fix SyntaxWarning for invalid escape character

## Change Summary

In order to fix warning messages in lambda logs
```
SyntaxWarning: invalid escape sequence '\.'
```


## PR Checklist

- [x] I've read and followed the [Contributing Guide](https://github.com/trendmicro/cloudone-filestorage-plugins/blob/master/.github/CONTRIBUTING.md).
- Documents/Readmes
  - [ ] Updated accordingly
  - [x] Not required
- Plugins that have versioning
  - [ ] Version bumped and follows [Semantic Versioning](https://semver.org/)
  - [ ] (Azure Only): Ensure the version for the package location in `template.json` has been updated
  - [x] Not required

## Other Notes

<!-- Any other information, screenshots, or reference to issue(s) that would be useful for the reviewer. -->
